### PR TITLE
Add bind_uri and options attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ arch | Architecture for docker binary (note: Docker only currently supports x86_
 http_proxy | HTTP_PROXY environment variable | String | nil
 install_dir | Installation directory for docker binary | String | auto-detected (see attributes/default.rb)
 install_type | Installation type for docker ("binary", "package" or "source") | String | "package"
+bind_uri | The location to that docker should bind to. Something | String | tcp://0.0.0.0:4243 (docker default)
+options | Additional options to pass to docker. These could be flags like "-api-enable-cors". | String | nil
 
 ### Binary Attributes
 

--- a/templates/default/docker.conf.erb
+++ b/templates/default/docker.conf.erb
@@ -11,5 +11,5 @@ script
     env HTTP_PROXY=<%= node['docker']['http_proxy'] %>
     <% end %>
     test -f /etc/default/locale && . /etc/default/locale || true
-    LANG=$LANG LC_ALL=$LANG <%= node['docker']['install_dir'] %>/docker -d
+    LANG=$LANG LC_ALL=$LANG <%= node['docker']['install_dir'] %>/docker -d<% if node['docker']['bind_uri'] %> -H="<%= node['docker']['bind_uri'] %>"<% end %><% if node['docker']['options'] %> <%= node['docker']['options'] %><% end %>
 end script


### PR DESCRIPTION
Adding two attributes to specify `bind_uri`, a binding location (like 0.0.0.0 instead of the default localhost, or another port instead of the default 4243), and `options` to allow additional things to passed to docker, like `-api-enable-cors`.

I'm new to docker but these were two things I needed to get [dockerui](http://github.com/crosbymichael/dockerui) up and running.
