### PR TITLE
Update APT repository for Docker 0.6+.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,8 +48,9 @@ default['docker']['binary']['url'] = "http://get.docker.io/builds/Linux/#{node['
 # Package attributes
 case node['platform']
 when "ubuntu"
-  default['docker']['package']['distribution'] = node['lsb']['codename']
-  default['docker']['package']['repo_url'] = "http://ppa.launchpad.net/dotcloud/lxc-docker/ubuntu"
+  default['docker']['package']['distribution'] = "docker"
+  default['docker']['package']['repo_url'] = "https://get.docker.io/ubuntu"
+  default['docker']['package']['repo_key'] = "http://get.docker.io/gpg"
 end
 
 # Source attributes

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -23,6 +23,7 @@ when "ubuntu"
     uri node['docker']['package']['repo_url']
     distribution node['docker']['package']['distribution']
     components [ "main" ]
+    key node['docker']['package']['repo_key']
   end
 end
 


### PR DESCRIPTION
Hey there!

Looks like upstream has deployed their own APT repository for the 0.6.0 release and beyond:

http://docs.docker.io/en/latest/installation/ubuntulinux/

Cheers, and thanks for this cookbook!
