### PR TITLE
stop service before start so custom docker.conf can be picked up

### DIFF
--- a/recipes/upstart.rb
+++ b/recipes/upstart.rb
@@ -24,6 +24,14 @@ template "/etc/init/docker.conf" do
   group "root"
 end
 
+# stop service if running - Ubuntu apt-get install automatically starts the service
+# and docker.conf is written after the package installation.
+service "docker stop" do
+  service_name "docker"
+  provider Chef::Provider::Service::Upstart
+  action :stop
+end
+
 service "docker" do
   provider Chef::Provider::Service::Upstart
   supports :status => true, :restart => true, :reload => true


### PR DESCRIPTION
when using the default recipe, package install will start the service immediately upon installation. After that, the upstart recipe will be called, creating a new docker.conf file which will not be picked up by docker which is already running. This patch makes sure docker is stopped before starting it to pickup the new docker.conf. 
