### PR TITLE
Added timeout and docker file directory

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -22,7 +22,7 @@ include Chef::Mixin::ShellOut
 
 def load_current_resource
   @current_resource = Chef::Resource::DockerContainer.new(new_resource)
-  dps = shell_out("docker ps -a -notrunc", :timeout => new_resource.cmd_timeout || 60)
+  dps = shell_out("docker ps -a -notrunc", :timeout => new_resource.cmd_timeout)
   dps.stdout.each_line do |dps_line|
     next unless dps_line.include?(new_resource.image) && dps_line.include?(new_resource.command)
     container_ps = dps_line.split(%r{\s\s+})
@@ -62,7 +62,8 @@ action :run do
     run_args += " -privileged" if new_resource.privileged
     run_args += " -u #{new_resource.user}" if new_resource.user
     run_args += " -v #{new_resource.volume}" if new_resource.volume
-    dr = shell_out("docker run #{run_args} #{new_resource.image} #{new_resource.command}", :timeout => new_resource.cmd_timeout || 60)
+    run_args += " -w #{new_resource.working_directory}" if new_resource.working_directory
+    dr = shell_out("docker run #{run_args} #{new_resource.image} #{new_resource.command}", :timeout => new_resource.cmd_timeout)
     new_resource.id(dr.stdout.chomp)
     new_resource.updated_by_last_action(true)
   end
@@ -79,11 +80,11 @@ action :stop do
 end
 
 def remove
-  shell_out("docker rm #{current_resource.id}", :timeout => new_resource.cmd_timeout || 60)
+  shell_out("docker rm #{current_resource.id}", :timeout => new_resource.cmd_timeout)
 end
 
 def restart
-  shell_out("docker restart #{current_resource.id}", :timeout => new_resource.cmd_timeout || 60)
+  shell_out("docker restart #{current_resource.id}", :timeout => new_resource.cmd_timeout)
 end
 
 def running?
@@ -91,9 +92,9 @@ def running?
 end
 
 def start
-  shell_out("docker start #{current_resource.id}", :timeout => new_resource.cmd_timeout || 60)
+  shell_out("docker start #{current_resource.id}", :timeout => new_resource.cmd_timeout)
 end
 
 def stop
-  shell_out("docker stop #{current_resource.id}", :timeout => new_resource.cmd_timeout || 60)
+  shell_out("docker stop #{current_resource.id}", :timeout => new_resource.cmd_timeout)
 end

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -22,7 +22,7 @@ include Chef::Mixin::ShellOut
 
 def load_current_resource
   @current_resource = Chef::Resource::DockerImage.new(new_resource)
-  di = shell_out("docker images -a", :timeout => new_resource.cmd_timeout || 60)
+  di = shell_out("docker images -a", :timeout => new_resource.cmd_timeout)
   if di.stdout.include?(new_resource.image_name)
     di.stdout.each_line do |di_line|
       next unless di_line.include?(new_resource.image_name)
@@ -42,7 +42,7 @@ action :pull do
     pull_args = ""
     pull_args += " -registry #{new_resource.registry}" if new_resource.registry
     pull_args += " -t #{new_resource.tag}" if new_resource.tag
-    shell_out("docker pull #{new_resource.image_name} #{pull_args}", :timeout => new_resource.cmd_timeout || 60)
+    shell_out("docker pull #{new_resource.image_name} #{pull_args}", :timeout => new_resource.cmd_timeout)
     new_resource.updated_by_last_action(true)
   end
 end
@@ -53,10 +53,10 @@ action :build do
     full_image_name += ":#{new_resource.tag}" if new_resource.tag
     if new_resource.dockerfile
       command = "- < #{new_resource.dockerfile}"
-    elsif new_resource.dockerfile_directory
-      command = "#{new_resource.dockerfile_directory}"
+    elsif new_resource.path
+      command = "#{new_resource.path}"
     end
-    shell_out("docker build -t #{full_image_name} #{command}", :timeout => new_resource.cmd_timeout || 60)
+    shell_out("docker build -t #{full_image_name} #{command}", :timeout => new_resource.cmd_timeout)
     new_resource.updated_by_last_action(true)
   end
 end
@@ -67,7 +67,7 @@ action :remove do
 end
 
 def remove
-  shell_out("docker rmi #{new_resource.image_name}", :timeout => new_resource.cmd_timeout || 60)
+  shell_out("docker rmi #{new_resource.image_name}", :timeout => new_resource.cmd_timeout)
 end
 
 def installed?

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -36,4 +36,5 @@ attribute :stdin, :kind_of => [TrueClass, FalseClass]
 attribute :privileged, :kind_of => [TrueClass, FalseClass]
 attribute :user, :kind_of => [String]
 attribute :volume, :kind_of => [String]
-attribute :cmd_timeout, :kind_of => [Integer]
+attribute :working_directory, :kind_of => [String]
+attribute :cmd_timeout, :kind_of => [Integer], :default => 60

--- a/resources/image.rb
+++ b/resources/image.rb
@@ -29,5 +29,5 @@ attribute :registry, :kind_of => [String]
 attribute :repository, :kind_of => [String]
 attribute :tag, :kind_of => [String]
 attribute :dockerfile, :kind_of => [String]
-attribute :cmd_timeout, :kind_of => [Integer]
-attribute :dockerfile_directory, :kind_of => [String]
+attribute :cmd_timeout, :kind_of => [Integer], :default => 60
+attribute :path, :kind_of => [String]


### PR DESCRIPTION
I added the option of passing a timeout parameter to the shell out method to prevent an erroneous failure due to long-running image builds. I also added the option to pass the directory that contains the dockerfile so that the ADD parameter in the dockerfile can be supported.
