### PR TITLE
Do not modprobe AUFS module at each deployment

### DIFF
--- a/recipes/aufs.rb
+++ b/recipes/aufs.rb
@@ -36,5 +36,6 @@ when "ubuntu"
 
   modules "aufs" do
     action :load
+    not_if "lsmod | grep aufs"
   end
 end


### PR DESCRIPTION
Add not_if condition. For chef, it means that
there is less resources updated.
