### PR TITLE
Fixed init script change reloading

### DIFF
--- a/recipes/upstart.rb
+++ b/recipes/upstart.rb
@@ -5,7 +5,9 @@ template '/etc/init/docker.conf' do
   group 'root'
   # lxc-docker package automatically starts service
   # must restart immediately to catch Upstart config changes after install
-  notifies :restart, 'service[docker]', :immediately
+  # Need to stop&start, restart doesn't reload initd changes
+  notifies :stop, 'service[docker]', :immediately
+  notifies :start, 'service[docker]', :immediately
 end
 
 service 'docker' do


### PR DESCRIPTION
When Chef changes init script, for example add bind_uri, restart
doesn't load the command line arguments. Need to stop and start to
get changes affect.

Demo: 
- Install Docker to empty machine with :bind-uri defined. 
- Docker get started but doesn't listen on given bind-uri. 
- If you run command "restart docker" it still doesn't listen on given bind uri.
- If you run commands "stop docker" and "start docker" it will start to listen the given bind-uri.
