### PR TITLE
Option 1: Simplify how we find extras package

### DIFF
--- a/recipes/aufs.rb
+++ b/recipes/aufs.rb
@@ -1,11 +1,10 @@
 case node['platform']
 when 'ubuntu'
-  # If aufs isn't available, do our best to install the correct linux-image-extra package.
-  uname = Mixlib::ShellOut.new('uname -r').run_command.stdout.strip
-  extra_package = 'linux-image-extra-' + uname
+  # Verify the package exists before we attempt to install it
+  extra_package = Mixlib::ShellOut.new('apt-cache search linux-image-extra-' + node['kernel']['release']).run_command.stdout.split(' ').first.strip
   unless extra_package.empty?
     package extra_package do
-      not_if 'modprobe -l | grep aufs'
+      not_if 'modprobe -l | grep -q aufs'
     end
   end
 


### PR DESCRIPTION
This completely removes the old logic. PR #35 keeps the older logic, hidden behind an attribute.
- Current regexp breaks on kernels with double-digit versions (i.e.
  3.11.0-13-generic)
- Can't find a sensible reason why we can't plug in uname -r directly

This is tested working on Ubuntu Precise 12.04 and tested in theory on Ubuntu Saucy 13.10 (although other problems prevent this cookbook from working there yet; see my recently filed issue).
