### PR TITLE
dont include aufs recipe on ubuntu 13.10 and up; don't require docker::lxc for package installs

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,6 +6,7 @@ when 'ubuntu'
   include_recipe 'apt'
   package 'apt-transport-https'
   package 'bsdtar'
+  include_recipe 'docker::lxc' unless node['docker']['install_type'] == 'package'
   if Chef::VersionConstraint.new('< 13.10').include?(node['platform_version'])
     include_recipe 'docker::aufs'
   end


### PR DESCRIPTION
Based on PR #34 but implemented behind an if statement as suggested by @bflad.
