### PR TITLE
Fix NoMethodError bugs in docker::aufs recipe

### DIFF
--- a/recipes/aufs.rb
+++ b/recipes/aufs.rb
@@ -2,7 +2,7 @@ case node['platform']
 when 'ubuntu'
   # If aufs isn't available, do our best to install the correct linux-image-extra package.
   # Use kernel release for saucy and newer, otherwise use older, more compatible regexp match
-  if Gem::Version.new(node['platform_version']) < Gem::Version('13.10')
+  if Chef::Version.new(node['platform_version']) < Chef::Version.new('13.10')
     # Original method copied from https://github.com/thoward/docker-cookbook/blob/master/recipes/default.rb
     package_name = 'linux-image-extra-' + Mixlib::ShellOut.new("uname -r | grep --only-matching -e [0-9]\.[0-9]\.[0-9]-[0-9]*").run_command.stdout.strip
   else
@@ -12,7 +12,7 @@ when 'ubuntu'
 
   extra_package = Mixlib::ShellOut.new('apt-cache search ' + package_name).run_command.stdout.split(' ').first
   # Wait to strip until after checking for empty, to protect against nil errors
-  unless extra_package.empty?
+  unless extra_package.nil? || extra_package.empty?
     package extra_package.strip do
       not_if 'modprobe -l | grep aufs'
     end


### PR DESCRIPTION
Fixing some bugs introduced in #35:

```
NoMethodError
-------------
undefined method `empty?' for nil:NilClass '`

NoMethodError
-------------
undefined method `Version' for Gem:Module`
```

Tests passing via:
1. `bundle exec kitchen test ubuntu`
2. `bundle exec foodcritic .`
3. `bundle exec rubocop`
4. `bundle exec knife cookbook test`

Note: fedora-19 currently has a problem running the docker tests, but
this was already happening before #35.  Please see [this gist](https://gist.github.com/8216591)
