### PR TITLE
fix(upstart): Install inotify-tools if using upstart

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -237,6 +237,9 @@ def service_create_sysv
 end
 
 def service_create_upstart
+  # The upstart init script requires inotifywait, which is in inotify-tools
+  package 'inotify-tools'
+
   template "/etc/init/#{service_name}.conf" do
     source 'docker-container.conf.erb'
     cookbook new_resource.cookbook


### PR DESCRIPTION
- This should fix issue #41 I filed

My primary concern is that it appears inotify-tools is only available in RHEL via EPEL? Given they don't use upstart though, is this an issue? I don't really run any redhat-based OSes so it's a bit hard for me to tell.
