### PR TITLE
fix(whitespace): squeeze before printing log

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -10,7 +10,7 @@ def load_current_resource
   dps.stdout.each_line do |dps_line|
     next unless dps_line.include?(new_resource.image)
     next if new_resource.command && !dps_line.include?(new_resource.command)
-    Chef::Log.debug('Matched docker container: ' + dps_line)
+    Chef::Log.debug('Matched docker container: ' + dps_line.squeeze(' '))
     ps = dps_line.split(/\s\s+/)
     name = ps[6] || ps[5]
     @current_resource.container_name(name)


### PR DESCRIPTION
The new logging added last release is awesome, but a bit ugly in the logs. This just removes the extraneous whitespace so it's much more readable.
