### PR TITLE
added attribute to allow skipping aufs on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ http_proxy | HTTP_PROXY environment variable | String | nil
 image_cmd_timeout | image LWRP default cmd_timeout seconds | Fixnum | 300
 init_type | Init type for docker ("systemd", "sysv", or "upstart") | String | auto-detected (see attributes/default.rb)
 install_dir | Installation directory for docker binary | String | auto-detected (see attributes/default.rb)
+skip_aufs | skip the aufs recipe | Boolean | false
 install_type | Installation type for docker ("binary", "package" or "source") | String | "package"
 options | Additional options to pass to docker. These could be flags like "-api-enable-cors". | String | nil
 registry_cmd_timeout | registry LWRP default cmd_timeout seconds | Fixnum | 60

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision :chef_solo do |chef|
     chef.log_level = :debug
     chef.json = {
+      docker: {
+        skip_aufs: true
+      }
 
     }
     chef.run_list = [

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,8 @@ default['docker']['init_type'] = value_for_platform(
 
 default['docker']['container_init_type'] = node['docker']['init_type']
 
+default['docker']['skip_aufs'] = false
+
 default['docker']['install_type'] = value_for_platform(
   %w{ centos debian fedora redhat ubuntu } => {
     'default' => 'package'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,7 +9,7 @@ when 'debian', 'ubuntu'
       value 1
     end
   elsif node['platform'] == 'ubuntu' && Chef::VersionConstraint.new('< 13.10').include?(node['platform_version'])
-    include_recipe 'docker::aufs'
+    include_recipe 'docker::aufs' unless node['docker']['skip_aufs']
   end
 when 'oracle'
   include_recipe 'docker::cgroups'


### PR DESCRIPTION
added attribute to allow us to skip aufs on ubuntu OSes.    This is useful if a user wants to use a different storage backend like `device-mapper` ( may not be do-able yet though? )  also if the user wants to just use it as a client and not want to have to mess with their kernel.
