### PR TITLE
Add 'rm' attribute to image resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ image_url (*DEPRECATED*) | URL to grab image | String | nil
 path (*DEPRECATED*) | Local path to files | String | nil
 source | Source dockerfile/directory/URL to build | String | nil
 tag | Optional tag for image | String | nil
+rm | Remove intermediate containers after a successful build | TrueClass, FalseClass | false
 
 Build image from Dockerfile:
 

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -104,7 +104,7 @@ def build
     command = new_resource.source
   end
 
-  docker_cmd("build -t #{full_image_name} #{command}")
+  docker_cmd("build -rm=#{new_resource.rm} -t #{full_image_name} #{command}")
 end
 
 def docker_cmd(cmd, timeout = new_resource.cmd_timeout)

--- a/resources/image.rb
+++ b/resources/image.rb
@@ -20,3 +20,4 @@ attribute :registry, :kind_of => [String]
 attribute :repository, :kind_of => [String]
 attribute :source, :kind_of => [String]
 attribute :tag, :kind_of => [String]
+attribute :rm, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
Adding attribute to remove intermediate containers after a successful build. This makes things cleaner.
