### PR TITLE
current_resource attribute matching should also depend on container_name

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -13,6 +13,7 @@ def load_current_resource
     Chef::Log.debug('Matched docker container: ' + dps_line.squeeze(' '))
     ps = dps_line.split(/\s\s+/)
     name = ps[6] || ps[5]
+    next if new_resource.container_name && new_resource.container_name != name
     @current_resource.container_name(name)
     @current_resource.id(ps[0])
     @current_resource.running(true) if ps[4].include?('Up')


### PR DESCRIPTION
When attempting to execute action :run on multiple containers, the first docker will run successfully, and subsequent attempts will not perform any action (assuming the first docker started successfully); alternatively the subsequent attempts could also try to start the container if it failed to start originally.

This pull request will make it such that if container_name is defined, current_resource will also match on the container_name when determining container_id, and other attributes. If container_name is omitted, the provider will behave in the same fashion as before. My stack requires the execution of several :run actions with the same image / command / command line params but different container_names; I tested my recipe using this modified provider to ensure each container started successfully. I don't believe this should modify any other actions, although I have not fully tested this assumption. 
