### PR TITLE
Add image action pull_if_missing and chg pull to match cli

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,5 +18,10 @@ module Helpers
       end
       cli_line
     end
+
+    def inspect(id)
+      require 'json'
+      JSON.parse(docker_cmd('inspect', id).stdout)[0]
+    end
   end
 end

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -49,12 +49,20 @@ action :load do
   end
 end
 
-action :pull do
+action :pull_if_missing do
   unless installed?
     pull
     new_resource.updated_by_last_action(true)
   end
 end
+
+action :pull do
+  old_hash = docker_inspect(new_resource.image_name)[:id]
+  pull
+  new_hash = docker_inspect(new_resource.image_name)[:id]
+  new_resource.updated_by_last_action(new_hash != old_hash)
+end
+
 
 action :push do
   if installed?


### PR DESCRIPTION
- Add the pull_if_missing action to the image LWRP with the current functionality
- Modify the existing pull action to check the hash of the image before and after to determine if the resource updated (and notifications should be triggered)
- Add docker_inspect method to the helpers library

Addresses #54 
