### PR TITLE
Implement id checking when determining current_resource

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -10,9 +10,9 @@ def load_current_resource
   dps.stdout.each_line do |dps_line|
     ps = dps(dps_line)
     unless container_id_matches(ps['id'])
-        next unless container_image_matches(ps['image'])
-        next unless container_command_matches(ps['command'])
-        next unless container_name_matches(ps['names'])
+      next unless container_image_matches(ps['image'])
+      next unless container_command_matches(ps['command'])
+      next unless container_name_matches(ps['names'])
     end
     Chef::Log.debug('Matched docker container: ' + dps_line.squeeze(' '))
     @current_resource.container_name(ps['names'])


### PR DESCRIPTION
When executing action :kill on a container, I realized I would have to supply the image, command and container name to successfully find and kill said container. I was planning on simply providing the id, and using that as the uid to determine which container to kill. This pull request allows current_resource matching to be short circuited if provided a valid container id. 
- It's worth noting that in its current state, most actions will require that image, command, and name are provided in the LWRP in order to successfully execute the action. 
