### PR TITLE
Putting arguments in front of server

### DIFF
--- a/providers/registry.rb
+++ b/providers/registry.rb
@@ -36,5 +36,5 @@ def login
     'p' => new_resource.password,
     'u' => new_resource.username
   )
-  docker_cmd!("login #{new_resource.server} #{login_args}")
+  docker_cmd!("login #{login_args} #{new_resource.server} ")
 end


### PR DESCRIPTION
When trying to log in to a private registry (quay.io in my case), the login command only worked when I put the arguments before the server. This also matches with the usage docs (http://docs.docker.io/en/latest/reference/commandline/cli/#login):

```
Usage: docker login [OPTIONS] [SERVER]
```
