### PR TITLE
Changing logged_in? to check updated_by_last_action?

### DIFF
--- a/providers/registry.rb
+++ b/providers/registry.rb
@@ -27,7 +27,7 @@ EOM
 end
 
 def logged_in?
-  @current_resource || true
+  @current_resource.updated_by_last_action?
 end
 
 def login


### PR DESCRIPTION
I think the logged_in? method is always returning true. If the desired behavior is to only login to the registry once per chef run, does checking @new_resource.updated_by_last_action? do the trick.
