### PR TITLE
Fix argument order to pull when tag specified.

### DIFF
--- a/providers/image.rb
+++ b/providers/image.rb
@@ -199,7 +199,7 @@ def pull
     'registry' => new_resource.registry,
     't' => new_resource.tag
   )
-  docker_cmd!("pull #{new_resource.image_name} #{pull_args}")
+  docker_cmd!("pull #{pull_args} #{new_resource.image_name}")
 end
 
 def push

--- a/test/cookbooks/docker_test/recipes/image_lwrp.rb
+++ b/test/cookbooks/docker_test/recipes/image_lwrp.rb
@@ -1,8 +1,12 @@
-docker_image "base"
+docker_image "base" do
+  tag "ubuntu-quantal"
+end
+
 docker_image "busybox"
 docker_image 'bflad/testcontainerd'
 
 docker_image "base" do
+  tag "ubuntu-quantal"
   action :remove
 end
 


### PR DESCRIPTION
Fixes an error with pulling a container at a tag (docker requires all flag args before positional args). e.g. with the current impl you'll see:

```
Expected process to exit with [0], but received '2'       
---- Begin output of docker pull registry  -t 0.6.5 ----       
       STDOUT: 

       STDERR: Usage: docker pull NAME

       Pull an image or a repository from the registry

         -t="": Download tagged image in repository
       ---- End output of docker pull registry  -t 0.6.5 ----
       Ran docker pull registry  -t 0.6.5 returned 2
```
