### PR TITLE
Fix CommandTimeout handling

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -22,6 +22,9 @@ EOH
       end
     end
 
+    # Exception to signify that the docker command timed out.
+    class CommandTimeout < RuntimeError; end
+
     def cli_args(spec)
       cli_line = ''
       spec.each_pair do |arg, value|

--- a/providers/container.rb
+++ b/providers/container.rb
@@ -1,7 +1,5 @@
 include Helpers::Docker
 
-class CommandTimeout < RuntimeError; end
-
 def load_current_resource
   @current_resource = Chef::Resource::DockerContainer.new(new_resource)
   wait_until_ready!

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -1,7 +1,5 @@
 include Helpers::Docker
 
-class CommandTimeout < RuntimeError; end
-
 def load_current_resource
   wait_until_ready!
   @current_resource = Chef::Resource::DockerImage.new(new_resource)

--- a/providers/registry.rb
+++ b/providers/registry.rb
@@ -1,7 +1,5 @@
 include Helpers::Docker
 
-class CommandTimeout < RuntimeError; end
-
 def load_current_resource
   @current_resource = Chef::Resource::DockerRegistry.new(new_resource)
   wait_until_ready!


### PR DESCRIPTION
The refactor broke CommandTimeout handling, which will result
in a NameError. This fixes it by adding a new CommandTimeout
exception in scope and removing the old classes.

Here's an example error message:

```

       NameError

       ---------
       uninitialized constant Helpers::Docker::CommandTimeout


       Cookbook Trace:
       ---------------
       /tmp/kitchen/cookbooks/docker/libraries/helpers.rb:104:in `rescue in execute_cmd'
       /tmp/kitchen/cookbooks/docker/libraries/helpers.rb:101:in `execute_cmd'
       /tmp/kitchen/cookbooks/docker/libraries/helpers.rb:117:in `execute_cmd!'
       /tmp/kitchen/cookbooks/docker/libraries/helpers.rb:111:in `docker_cmd!'
       /tmp/kitchen/cookbooks/docker/providers/image.rb:202:in `pull'
       /tmp/kitchen/cookbooks/docker/providers/image.rb:70:in `block in class_from_file'

```

if you have a timeout. 
