### PR TITLE
Defines runner methods for ChefSpec matchers

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,4 +1,8 @@
 if defined?(ChefSpec)
+  ChefSpec::Runner.define_runner_method(:docker_container)
+  ChefSpec::Runner.define_runner_method(:docker_image)
+  ChefSpec::Runner.define_runner_method(:docker_registry)
+  
   # Docker registry
   def login_docker_registry(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry, :login, resource_name)


### PR DESCRIPTION
This enables us to target these resources by using `chef_run.docker_image('resource-name')`.

Example:

``` ruby
  it 'notifies the database container to redeploy' do
    image = chef_run.docker_image('database')
    expect(image).to notify('docker_container[database]').to(:redeploy).immediately
  end
```
