### PR TITLE
added remove_container for use with redeploy...

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -48,6 +48,9 @@ action :kill do
 end
 
 action :redeploy do
+  if service?
+    service_stop 
+  end
   remove_container if exists?
   run
   new_resource.updated_by_last_action(true)


### PR DESCRIPTION
 With out this the link argument gets passed if the container had on defined on it. 
