### PR TITLE
Fix and enhance docker_image pull/push behavior with Docker 0.10, fixes #142

### DIFF
--- a/providers/image.rb
+++ b/providers/image.rb
@@ -150,6 +150,12 @@ Please adjust node image_cmd_timeout attribute or this docker_image cmd_timeout 
 EOM
 end
 
+def image_and_tag_arg
+  docker_cmd_args = new_resource.image_name
+  docker_cmd_args += ":#{new_resource.tag}" if new_resource.tag
+  docker_cmd_args
+end
+
 def image_id_matches?(id)
   id.start_with?(new_resource.id)
 end
@@ -204,15 +210,18 @@ def load
 end
 
 def pull
-  pull_args = cli_args(
-    'registry' => new_resource.registry,
-    'tag' => new_resource.tag
-  )
-  docker_cmd!("pull #{pull_args} #{new_resource.image_name}")
+  docker_cmd!("pull #{registry_image_and_tag_arg}")
 end
 
 def push
-  docker_cmd!("push #{new_resource.image_name}")
+  docker_cmd!("push #{registry_image_and_tag_arg}")
+end
+
+def registry_image_and_tag_arg
+  docker_cmd_args = ''
+  docker_cmd_args += "#{new_resource.registry}/" if new_resource.registry
+  docker_cmd_args += image_and_tag_arg
+  docker_cmd_args
 end
 
 def remove


### PR DESCRIPTION
- Removes deprecated --registry and --tag CLI args from docker_image pull
- Adds support for registry attribute usage in docker_image pull and push
- Adds support for tag attribute usage in docker_image push
