### PR TITLE
Removing call to image_id_matches in load_current_resource

### DIFF
--- a/providers/image.rb
+++ b/providers/image.rb
@@ -7,10 +7,8 @@ def load_current_resource
   if dimages.stdout.include?(new_resource.image_name)
     dimages.stdout.each_line do |di_line|
       image = di(di_line)
-      unless image_id_matches?(image['id'])
-        next unless image_name_matches?(image['repository'])
-        next unless image_tag_matches_if_exists?(image['tag'])
-      end
+      next unless image_name_matches?(image['repository'])
+      next unless image_tag_matches_if_exists?(image['tag'])
       Chef::Log.debug('Matched docker image: ' + di_line.squeeze(' '))
       @current_resource.created(image['created'])
       @current_resource.repository(image['repository'])


### PR DESCRIPTION
Taking the call to `image_id_matches?` in the image LWRP's `load_current_resource` method solves the problem that I was having in #153. I'm not positive, but it looks like new_resource.id is always nil at the time that load_current_resource is called.
