### PR TITLE
Run apt recipe before LXC to make sure APT repos are up-to-date

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -65,6 +65,7 @@ suites:
 - name: docker-lwrp-lxc
   run_list:
   - recipe[minitest-handler]
+  - recipe[apt]
   - recipe[lxc]
   - recipe[docker_test::default]
   - recipe[docker_test::image_lwrp]


### PR DESCRIPTION
I added the `apt` cookbook to the Kitchen suite in order to avoid the following exception on `kitchen test`; is there a better way to do this?

```
 STDERR: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nspr/libnspr4_4.9.5-0ubuntu0.12.04.1_amd64.deb  404  Not Found [IP: 91.189.91.14 80]
 Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3_3.15.3-0ubuntu0.12.04.1_amd64.deb  404  Not Found [IP: 91.189.91.14 80]
 Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libx/libxml2/python-libxml2_2.7.8.dfsg-5.1ubuntu4.6_amd64.deb  404  Not Found [IP: 91.189.91.14 80]
 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
 ---- End output of apt-get -q -y install yum=3.2.25-1ubuntu2 ----
 Ran apt-get -q -y install yum=3.2.25-1ubuntu2 returned 100
```
