### PR TITLE
container/image id is given as nil. 

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -4,11 +4,9 @@ def load_current_resource
   @current_resource = Chef::Resource::DockerContainer.new(new_resource)
   wait_until_ready!
   docker_containers.each do |ps|
-    unless container_id_matches?(ps['id'])
-      next unless container_image_matches?(ps['image'])
-      next unless container_command_matches_if_exists?(ps['command'])
-      next unless container_name_matches_if_exists?(ps['names'])
-    end
+    next unless container_image_matches?(ps['image'])
+    next unless container_command_matches_if_exists?(ps['command'])
+    next unless container_name_matches_if_exists?(ps['names'])
     Chef::Log.debug('Matched docker container: ' + ps['line'].squeeze(' '))
     @current_resource.container_name(ps['names'])
     @current_resource.created(ps['created'])
@@ -204,7 +202,7 @@ end
 #
 # The array of hashes is returned.
 def docker_containers
-  dps = docker_cmd!('ps -a -notrunc')
+  dps = docker_cmd!('ps -a --no-trunc')
 
   lines = dps.stdout.lines.to_a
   ranges = get_ranges(lines[0])

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -3,14 +3,12 @@ include Helpers::Docker
 def load_current_resource
   wait_until_ready!
   @current_resource = Chef::Resource::DockerImage.new(new_resource)
-  dimages = docker_cmd('images -a -notrunc')
+  dimages = docker_cmd('images -a --no-trunc')
   if dimages.stdout.include?(new_resource.image_name)
     dimages.stdout.each_line do |di_line|
       image = di(di_line)
-      unless image_id_matches?(image['id'])
-        next unless image_name_matches?(image['repository'])
-        next unless image_tag_matches_if_exists?(image['tag'])
-      end
+      next unless image_name_matches?(image['repository'])
+      next unless image_tag_matches_if_exists?(image['tag'])
       Chef::Log.debug('Matched docker image: ' + di_line.squeeze(' '))
       @current_resource.created(image['created'])
       @current_resource.repository(image['repository'])


### PR DESCRIPTION
For a new_resource id is returned to be nil. So ignoring the check. 
Also the -notrunc is deprecated. moving it to --no-trunc.
