### PR TITLE
Fix NameError when displaying error messages for timed-out commands.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -211,7 +211,7 @@ EOH
 
     # the Error message to display if a command times out. Subclasses
     # may want to override this to provide more details on the timeout.
-    def command_timeout_error_message
+    def command_timeout_error_message(cmd)
       <<-EOM
 
 Command timed out:
@@ -232,7 +232,7 @@ EOM
       begin
         shell_out(cmd, :timeout => timeout)
       rescue Mixlib::ShellOut::CommandTimeout
-        raise CommandTimeout, command_timeout_error_message
+        raise CommandTimeout, command_timeout_error_message(cmd)
       end
     end
 

--- a/providers/container.rb
+++ b/providers/container.rb
@@ -226,7 +226,7 @@ def docker_containers
   end
 end
 
-def command_timeout_error_message
+def command_timeout_error_message(cmd)
   <<-EOM
 
 Command timed out:

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -140,7 +140,7 @@ def di(di_line)
   image
 end
 
-def command_timeout_error_message
+def command_timeout_error_message(cmd)
   <<-EOM
 
 Command timed out:

--- a/providers/registry.rb
+++ b/providers/registry.rb
@@ -20,7 +20,7 @@ action :login do
   end
 end
 
-def command_timeout_error_message
+def command_timeout_error_message(cmd)
   <<-EOM
 
 Command timed out:


### PR DESCRIPTION
As reported in #158 by @vblessing, when a subcommand times-out (which is too often to my taste) we get a `NameError` instead of the expected error message. The same problem happens for both image, registry and container providers due to code duplication. This modest (and untested) PR should fix it.
