### PR TITLE
adding test for sysv recipe (lifted directly from upstart test)

### DIFF
--- a/files/default/tests/minitest/sysv_test.rb
+++ b/files/default/tests/minitest/sysv_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path('../support/helpers', __FILE__)
+
+describe_recipe 'docker::sysv' do
+  include Helpers::Docker
+
+  it 'starts docker' do
+    if Helpers::Docker.using_docker_io_package?(node)
+      service('docker.io').must_be_running
+    else
+      service('docker').must_be_running
+    end
+  end
+end


### PR DESCRIPTION
I noticed this evening that when I was running on EL6 the test to ensure the service was running was getting tested. It appears the sysv_test.rb was missing. This is essentially a direct copy/paste from the upstart_test file
