### PR TITLE
Removing a container should also remove its cidfile.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -275,6 +275,14 @@ def remove_container
     'force' => new_resource.force
   )
   docker_cmd!("rm #{rm_args} #{current_resource.id}")
+  remove_cidfile
+end
+
+def remove_cidfile
+  # run at compile-time to ensure cidfile is gone before running docker_cmd()
+  file cidfile do
+    action :nothing
+  end.run_action(:delete)
 end
 
 def remove_link


### PR DESCRIPTION
Running a named container fails when its cidfile already exists (eg. left over from a previous deployment).

How to reproduce:

``` sh
vagrant@default-ubuntu-1404:~$ sudo docker run  --cidfile="/var/run/my-sample-app-0.cid" --detach=true --env-file="/etc/sample-docker-app.conf" --name="sample-docker-app-0" --publish="7022:22" --publish="7080:80" --volume="/var/log/nginx:/var/log/nginx/sample-docker-app" docker.si.perfect-memory.com/sample-docker-app:latest /sbin/my_init --enable-insecure-key
a1628f0d268404532cd19b0c8eadd2c01f8bb4558b174ebe8993ea946386e00d
vagrant@default-ubuntu-1404:~$ sudo docker rm -f sample-docker-app-0
sample-docker-app-0
vagrant@default-ubuntu-1404:~$ sudo docker run  --cidfile="/var/run/my-sample-app-0.cid" --detach=true --env-file="/etc/sample-docker-app.conf" --name="sample-docker-app-0" --publish="7022:22" --publish="7080:80" --volume="/var/log/nginx:/var/log/nginx/sample-docker-app" docker.si.perfect-memory.com/sample-docker-app:latest /sbin/my_init --enable-insecure-key
2014/06/11 15:17:32 Container ID file found, make sure the other container isn't running or delete /var/run/my-sample-app-0.cid
```

This PR removes the cidfile every time the container is removed (during redeploy) so that the container can be recreated safely, as suggested by the `docker run` error message in the above example.
