### PR TITLE
Fix command_timeout_error_message calls

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -212,7 +212,7 @@ EOH
 
     # the Error message to display if a command times out. Subclasses
     # may want to override this to provide more details on the timeout.
-    def command_timeout_error_message
+    def command_timeout_error_message(cmd)
       <<-EOM
 
 Command timed out:
@@ -233,7 +233,7 @@ EOM
       begin
         shell_out(cmd, :timeout => timeout)
       rescue Mixlib::ShellOut::CommandTimeout
-        raise CommandTimeout, command_timeout_error_message
+        raise CommandTimeout, command_timeout_error_message(cmd)
       end
     end
 

--- a/providers/container.rb
+++ b/providers/container.rb
@@ -225,7 +225,7 @@ def docker_containers
   end
 end
 
-def command_timeout_error_message
+def command_timeout_error_message(cmd)
   <<-EOM
 
 Command timed out:

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -140,7 +140,7 @@ def di(di_line)
   image
 end
 
-def command_timeout_error_message
+def command_timeout_error_message(cmd)
   <<-EOM
 
 Command timed out:

--- a/providers/registry.rb
+++ b/providers/registry.rb
@@ -20,7 +20,7 @@ action :login do
   end
 end
 
-def command_timeout_error_message
+def command_timeout_error_message(cmd)
   <<-EOM
 
 Command timed out:


### PR DESCRIPTION
Prior to this fix, any command timeout fails with the unintended and unhelpful exception

```
NameError
---------
Cannot find a resource for cmd on ubuntu version 12.04
```
