### PR TITLE
Fix docker_inspect_id for docker 1.0+

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -156,7 +156,8 @@ EOH
 
     def docker_inspect_id(id)
       inspect = docker_inspect(id)
-      inspect['id'] if inspect
+      # in docker < 1.0.0 the field is called 'id', but docker >= 1.0.0 it's called 'Id'.
+      (inspect['id'] || inspect['Id']) if inspect
     end
 
     def dockercfg_parse


### PR DESCRIPTION
This fixes docker_inspect_id for docker 1.0+. The JSON format for
`docker inspect` changed, and this supports the new format in a
backwards-compatible way.

This should fix issues with notifications from a `docker_image` with
`action :pull` by properly detecting changes in the id.
