### PR TITLE
specify upstart as service provider for cgroup on ubuntu 14.04

### DIFF
--- a/recipes/cgroups.rb
+++ b/recipes/cgroups.rb
@@ -22,6 +22,7 @@ when 'ubuntu'
   else
     service 'cgroup-lite' do
       action :start
+      provider Chef::Provider::Service::Upstart if node['platform_version'] == '14.04'
     end
   end
 end


### PR DESCRIPTION
I'm getting the following error when I run this on ubuntu 14.04:
## Errno::ENOENT

No such file or directory - /etc/init.d/cgroup-lite start

this fixes it
