### PR TITLE
Fix value_for_platform package attributes for ubuntu 14.04.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,7 +90,7 @@ default['docker']['package']['name'] = value_for_platform(
     'default' => 'homebrew/binary/docker'
   },
   'ubuntu' => {
-    %w(12.04 12.10 13.04 13.10) => 'lxc-docker',
+    %w(12.04 12.10 13.04 13.10 14.04) => 'lxc-docker',
     'default' => 'docker.io'
   },
   'default' => nil
@@ -100,7 +100,7 @@ default['docker']['package']['repo_url'] = value_for_platform(
     'default' => 'https://get.docker.io/ubuntu'
   },
   'ubuntu' => {
-    %w(12.04 12.10 13.04 13.10) => 'https://get.docker.io/ubuntu',
+    %w(12.04 12.10 13.04 13.10 14.04) => 'https://get.docker.io/ubuntu',
     'default' => nil
   },
   'default' => nil


### PR DESCRIPTION
#168 allowed to override the name of the docker package to install, with default of `lxc-docker` for all ubuntu and debian platform. However, the refactoring done in c4f1570356471c6c220b2c0b7615bd73106f1f0f broke it for me, because I run ubuntu 14.04 which is not listed in the `value_for_platform` cases.

This PR fixes it for ubuntu 14.04, but does not handle the upcoming 14.10 and later releases (which are likely to be affected too).
