### PR TITLE
Generate no cidfile by default, even when deploying as service.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -109,11 +109,7 @@ action :wait do
 end
 
 def cidfile
-  if service?
-    new_resource.cidfile || "/var/run/#{service_name}.cid"
-  else
-    new_resource.cidfile
-  end
+  new_resource.cidfile
 end
 
 def commit


### PR DESCRIPTION
This PR remove the default value of `/var/run/#{service_name}.cid` when deploying container as a service. In other words, this means that containers will be deployed without a cidfile unless docker_container is configured with an explicit value for its cidfile attribute.

The main reason for that (slightly breaking) change is that :
- cidfiles are created by default in `/var/run` which is flushed at every reboot (tmpfs)
- `docker start` won't recreate cidfiles (only `docker run --cidfile` will)

My conclusion is that since the cidfiles we generate in `/var/run` do not survive reboots they cannot be relied upon and should not be generated by default.

My other reasons:
- containers can run just fine without cidfiles
- the service scripts do not use them (`fgrep -r cid` shows that no code depends on them in the cookbook)
- cidfiles complicate redeploys (`docker run` won't recreate a named container when there is a stale cidfile, see #164)

In the past I hacked around the cidfile issue by configuring my docker_container resources with `cidfile ''` but recent dockers (post 0.9) choke when `docker run` is invoked with `--cidfile=''`.
