### PR TITLE
Fixed remove_link container action.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -292,9 +292,12 @@ end
 def remove_link
   return false if new_resource.link.nil? || new_resource.link.empty?
   rm_args = cli_args(
-    'link' => new_resource.link
+    'link' => true
   )
-  docker_cmd!("rm #{rm_args} #{current_resource.id}")
+  link_args = Array(new_resource.link).map { |link|
+    container_name + '/' + link
+  }
+  docker_cmd!("rm #{rm_args} #{link_args.join(' ')}")
 end
 
 def remove_volume


### PR DESCRIPTION
This PR fixes the new docker_container remove_link action that was introduced in e298547. The feature was broken because the generated docker_cmd did not respect the syntax of `docker rm --link`.

Given the following containers:

``` sh
$ docker run --rm -t -i --name myssh -p 22222:22 busybox:ubuntu-14.04 /bin/sh
$ docker run --rm -t -i --link myssh:ssh --name jovial_franklin busybox:ubuntu-14.04 /bin/sh
```

And the following chef resource:

``` ruby
docker_container 'jovial_franklin' do
  link 'ssh'
  action :remove_container
end
```

Before this PR, the generated docker_cmd would generate execute like this:

``` sh
$ docker rm  --link="ssh" 821a290387c0b44032a09aa9b85d0247d72852c5275e49c83417ebd0a38028de
invalid boolean value "ssh" for  --link: strconv.ParseBool: parsing "ssh": invalid syntax

Usage: docker rm [OPTIONS] CONTAINER [CONTAINER...]

Remove one or more containers

  -f, --force=false      Force removal of running container
  -l, --link=false       Remove the specified link and not the underlying container
  -v, --volumes=false    Remove the volumes associated to the container
```

After this PR we now have:

```
$ docker rm --link=true jovial_franklin/ssh
```

Which should work as expected.
