### PR TITLE
fixed pull notification for tagged images

### DIFF
--- a/providers/image.rb
+++ b/providers/image.rb
@@ -64,9 +64,9 @@ action :pull_if_missing do
 end
 
 action :pull do
-  old_hash = docker_inspect_id(new_resource.image_name)
+  old_hash = docker_inspect_id(image_and_tag_arg)
   pull
-  new_hash = docker_inspect_id(new_resource.image_name)
+  new_hash = docker_inspect_id(image_and_tag_arg)
   new_resource.updated_by_last_action(new_hash != old_hash)
 end
 


### PR DESCRIPTION
The image pull action now uses `image_and_tag_arg` instead of only the `image_name`.

Only comparing the id of the image with the `image_name` will result in no update of the resource when you are actually pulling a tagged image and therefore no notify actions will be raised.
