### PR TITLE
Fix incorrect loading of container name when links are present.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -6,7 +6,11 @@ def load_current_resource
   docker_containers.each do |ps|
     next unless container_matches?(ps)
     Chef::Log.debug('Matched docker container: ' + ps['line'].squeeze(' '))
-    @current_resource.container_name(ps['names'])
+    detected_container_name = ps['names'].  # out of all raw names,
+      split(',').                           # extract the different names,
+      reject { |n| n.include?('/') }.       # filter out links (eg. 'my-app/db')
+      fetch(0)                              # returning main name (always exist)
+    @current_resource.container_name(detected_container_name)
     @current_resource.created(ps['created'])
     @current_resource.id(ps['id'])
     @current_resource.status(ps['status'])


### PR DESCRIPTION
# Bug summary

The docker_container provider will incorrectly attempt to recreate the docker container if the container already exists and has other containers linking to it.
# How to reproduce
1. declare a docker_container resource (with `docker run --name='my-db'`)
2. declare another docker_container resource that link to the first one (eg. `docker run --name my-app --link my-db:db`)
3. run chef-client, it passes (and the link can be seen in output of `docker ps`)
4. run chef-client again, docker will fail with the following message:

```
Error response from daemon: Conflict, The name my-db is already assigned to d0ac4cf80ab1. You have to delete (or rename) that container to be able to assign my-db to a container again.
```

Here are my containers as listed in `docker ps`:

```
a6ebcb14df56        registry.local/my-db:latest   "/sbin/my_init --ena   44 minutes ago      Up 44 minutes       1337/tcp     my-db                   
d0ac4cf80ab1        registry.local/my-app:latest   "/sbin/my_init --ena   45 minutes ago      Up 45 minutes       80/tcp     my-app,my-db/db   
```

The reason this happens is because the docker_container provider uses the raw name (as listed in docker ps) as default value for `@current_resource.container_name`; in my example, this means that the providers loads `my-app,my-db/db` as the container_name instead of `my-db` ; since the provider (incorrectly) filled the container_name attribute then it will wrongly think that the container does not exist and attempt to create it with the `run action` ; then `docker run` will fail with the above message because the container named `my-db` already exists.
# Suggested fix

This simple PR should fix the problem by trying to guess which is the `main` container name from raw `docker ps` output. I considered that every names which contain a `'/'` character are link names and should be ignored, this works fine enough for me.
