### PR TITLE
Fixed current_resource.name assignment in providers.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -1,7 +1,7 @@
 include Helpers::Docker
 
 def load_current_resource
-  @current_resource = Chef::Resource::DockerContainer.new(new_resource)
+  @current_resource = Chef::Resource::DockerContainer.new(new_resource.name)
   wait_until_ready!
   docker_containers.each do |ps|
     next unless container_matches?(ps)

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -2,7 +2,7 @@ include Helpers::Docker
 
 def load_current_resource
   wait_until_ready!
-  @current_resource = Chef::Resource::DockerImage.new(new_resource)
+  @current_resource = Chef::Resource::DockerImage.new(new_resource.name)
   dimages = docker_cmd('images -a --no-trunc')
   if dimages.stdout.include?(new_resource.image_name)
     dimages.stdout.each_line do |di_line|

--- a/providers/registry.rb
+++ b/providers/registry.rb
@@ -1,7 +1,7 @@
 include Helpers::Docker
 
 def load_current_resource
-  @current_resource = Chef::Resource::DockerRegistry.new(new_resource)
+  @current_resource = Chef::Resource::DockerRegistry.new(new_resource.name)
   wait_until_ready!
   dockercfg = dockercfg_parse
   if dockercfg && login_matches(dockercfg[new_resource.server])


### PR DESCRIPTION
While investigating another issue, I found out that the load_current_resource methods all providers initialize the current_resource with the new_resource instance. This is incorrect (even if this does not stop the resources from converging) but it makes inspecting the current_resource more difficult to read (the name attribute will be an object instead of the expected string).

In the example given in the [official documentation](http://docs.getchef.com/lwrp_custom_provider.html#load-current-resource) the current_resource is instantiated using the new_resource name attribute, which is exactly what this PR does.
