### PR TITLE
Added CentOS 7 support (docker-io package changed to docker)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,7 +80,11 @@ default['docker']['package']['name'] = value_for_platform(
   'amazon' => {
     'default' => 'docker'
   },
-  %w(centos fedora redhat) => {
+  'centos' => {
+    '6.5' => 'docker-io',
+    'default' => 'docker'
+  },
+  %w(fedora redhat) => {
     'default' => 'docker-io'
   },
   'debian' => {


### PR DESCRIPTION
The Chef run was failing on installing the `docker-io` package on CentOS 7. This change fixes this by installing Docker using the correct `docker` package when installing on any version of CentOS besides 6.5, which still uses `docker-io`.
