### PR TITLE
Ubuntu 14.10 fix for cgroups upstart.

### DIFF
--- a/recipes/cgroups.rb
+++ b/recipes/cgroups.rb
@@ -23,7 +23,7 @@ when 'ubuntu'
     service 'cgroup-lite' do
       action :start
       # WORKAROUND: CHEF-5276, fixed in Chef 11.14
-      provider Chef::Provider::Service::Upstart if node['platform_version'] == '14.04' || node['platform_version'] == '14.10'
+      provider Chef::Provider::Service::Upstart if %w(14.04 14.10).include?(node['platform_version'])
     end
   end
 end


### PR DESCRIPTION
Just a small fix for ubuntu 14.10 and upstart.
