### PR TITLE
Fix runit container template

### DIFF
--- a/templates/default/sv-docker-container-run.erb
+++ b/templates/default/sv-docker-container-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
-exec <%= Docker::Helpers.executable(node) %> start <%= @options['service_name'] %> || true
+<%= Docker::Helpers.executable(node) %> start <%= @options['service_name'] %> || true
 exec <%= Docker::Helpers.executable(node) %> attach <%= @options['service_name'] %>


### PR DESCRIPTION
The current template tries to run two successive lines with `exec`. But since `exec` causes the current process to be replaced, the second line is never run. This causes runit to always report that the container service is down and to continually try to restart it.

Just remove the first exec to fix.
