### PR TITLE
Adding NO_PROXY environment variable support.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Docker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.35.2'
+version '0.35.3'
 
 recipe 'docker', 'Installs/Configures Docker'
 recipe 'docker::aufs', 'Installs/Loads AUFS Linux module'

--- a/templates/default/docker.service.erb
+++ b/templates/default/docker.service.erb
@@ -11,6 +11,9 @@ Environment="DOCKER_RAMDISK=<%= node['docker']['ramdisk'] %>"
 <% if node['docker']['http_proxy'] -%>
 Environment="HTTP_PROXY=<%= node['docker']['http_proxy'] %>"
 <% end -%>
+<% if node['docker']['no_proxy'] -%>
+Environment="NO_PROXY=<%= node['docker']['no_proxy'] %>"
+<% end -%>
 <% if node['docker']['tmpdir'] -%>
 Environment="TMPDIR=<%= node['docker']['tmpdir'] %>"
 <% end -%>

--- a/templates/default/docker.sysconfig.erb
+++ b/templates/default/docker.sysconfig.erb
@@ -23,6 +23,12 @@ DOCKER_RAMDISK=<%= node['docker']['ramdisk'] %>
 export HTTP_PROXY=<%= node['docker']['http_proxy'] %>
 <% end -%>
 
+# In case you need a proxy to hit a public index, but also need to hit a private
+# index not accessible via the proxy, use no_proxy
+<% if node['docker']['no_proxy'] -%>
+export NO_PROXY=<%= node['docker']['no_proxy'] %>
+<% end -%>
+
 # This is also a handy place to tweak where Docker's temporary files go.
 <% if node['docker']['tmpdir'] -%>
 export TMPDIR="<%= node['docker']['tmpdir'] %>"

--- a/templates/default/sv-docker-run.erb
+++ b/templates/default/sv-docker-run.erb
@@ -6,6 +6,9 @@ export DOCKER_RAMDISK=<%= node['docker']['ramdisk'] %>
 <% if node['docker']['http_proxy'] -%>
 export HTTP_PROXY=<%= node['docker']['http_proxy'] %>
 <% end -%>
+<% if node['docker']['no_proxy'] -%>
+export NO_PROXY=<%= node['docker']['no_proxy'] %>
+<% end -%>
 <% if node['docker']['tmpdir'] -%>
 export TMPDIR=<%= node['docker']['tmpdir'] %>
 <% end -%>


### PR DESCRIPTION
When defining a PROXY to connect to a public docker index, also allow the use of NO_PROXY to connect to private index.

Fixes issue #227 
