### PR TITLE
Added support for the 'insecure-registry' docker daemon option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ group | Group for docker socket and group_members | String | nil (implicitly doc
 host | Socket(s) that docker should bind | String, Array | unix:///var/run/docker.sock
 http_proxy | HTTP_PROXY environment variable | String | nil
 icc | Enable inter-container communication | TrueClass, FalseClass | nil (implicitly true)
+insecure-registry | List of well-known insecure registries | String, Array | nil
 ip | Default IP address to use when binding container ports | String | nil (implicitly 0.0.0.0)
 iptables | Enable Docker's addition of iptables rules | TrueClass, FalseClass | nil (implicitly true)
 logfile | Set custom DOCKER_LOGFILE | String | nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -146,6 +146,7 @@ default['docker']['host'] =
   end
 default['docker']['http_proxy'] = nil
 default['docker']['icc'] = nil
+default['docker']['insecure-registry'] = nil
 default['docker']['ip'] = nil
 default['docker']['iptables'] = nil
 default['docker']['mtu'] = nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -86,6 +86,7 @@ EOH
         'graph' => node['docker']['graph'],
         'group' => node['docker']['group'],
         'icc' => node['docker']['icc'],
+        'insecure-registry' => Array(node['docker']['insecure-registry']),
         'ip' => node['docker']['ip'],
         'iptables' => node['docker']['iptables'],
         'mtu' => node['docker']['mtu'],

--- a/spec/systemd_spec.rb
+++ b/spec/systemd_spec.rb
@@ -269,6 +269,32 @@ describe 'docker::systemd' do
     end
   end
 
+  context 'when insecure-registry is set with String' do
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new
+      runner.node.set['docker']['insecure-registry'] = 'registry.example.com:1337'
+      runner.converge(described_recipe)
+    end
+
+    it 'adds insecure-registry flag to docker service' do
+      expect(chef_run).to render_file('/usr/lib/systemd/system/docker.service').with_content(
+        %r{^ExecStart=/usr/bin/docker -d.* --insecure-registry=registry\.example\.com:1337.*})
+    end
+  end
+
+  context 'when insecure-registry is set with Array' do
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new
+      runner.node.set['docker']['insecure-registry'] = %w(registry.example.com:1337 registry.example.com:1338)
+      runner.converge(described_recipe)
+    end
+
+    it 'adds insecure-registry flags to docker service' do
+      expect(chef_run).to render_file('/usr/lib/systemd/system/docker.service').with_content(
+        %r{^ExecStart=/usr/bin/docker -d.* --insecure-registry=registry\.example\.com:1337 --insecure-registry=registry\.example\.com:1338.*})
+    end
+  end
+
   context 'when ip is set' do
     let(:chef_run) do
       runner = ChefSpec::Runner.new

--- a/spec/sysv_spec.rb
+++ b/spec/sysv_spec.rb
@@ -280,6 +280,32 @@ describe 'docker::sysv' do
     end
   end
 
+  context 'when insecure-registry is set with String' do
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new
+      runner.node.set['docker']['insecure-registry'] = 'registry.example.com:1337'
+      runner.converge(described_recipe)
+    end
+
+    it 'adds insecure-registry flag to docker service' do
+      expect(chef_run).to render_file('/etc/default/docker').with_content(
+        /^DOCKER_OPTS='.* --insecure-registry=registry\.example\.com:1337.*'$/)
+    end
+  end
+
+  context 'when insecure-registry is set with Array' do
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new
+      runner.node.set['docker']['insecure-registry'] = %w(registry.example.com:1337 registry.example.com:1338)
+      runner.converge(described_recipe)
+    end
+
+    it 'adds insecure-registry flags to docker service' do
+      expect(chef_run).to render_file('/etc/default/docker').with_content(
+        /^DOCKER_OPTS='.* --insecure-registry=registry\.example\.com:1337 --insecure-registry=registry\.example\.com:1338.*'$/)
+    end
+  end
+
   context 'when ip is set' do
     let(:chef_run) do
       runner = ChefSpec::Runner.new

--- a/spec/upstart_spec.rb
+++ b/spec/upstart_spec.rb
@@ -281,6 +281,32 @@ describe 'docker::upstart' do
     end
   end
 
+  context 'when insecure-registry is set with String' do
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new
+      runner.node.set['docker']['insecure-registry'] = 'registry.example.com:1337'
+      runner.converge(described_recipe)
+    end
+
+    it 'adds insecure-registry flag to docker service' do
+      expect(chef_run).to render_file('/etc/default/docker').with_content(
+        /^DOCKER_OPTS='.* --insecure-registry=registry\.example\.com:1337.*'$/)
+    end
+  end
+
+  context 'when insecure-registry is set with Array' do
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new
+      runner.node.set['docker']['insecure-registry'] = %w(registry.example.com:1337 registry.example.com:1338)
+      runner.converge(described_recipe)
+    end
+
+    it 'adds insecure-registry flags to docker service' do
+      expect(chef_run).to render_file('/etc/default/docker').with_content(
+        /^DOCKER_OPTS='.* --insecure-registry=registry\.example\.com:1337 --insecure-registry=registry\.example\.com:1338.*'$/)
+    end
+  end
+
   context 'when ip is set' do
     let(:chef_run) do
       runner = ChefSpec::Runner.new


### PR DESCRIPTION
As promised in #231, here is my PR to add support for the new (and mandatory for us private registry users as of docker 1.3.1) 'insecure-registry' docker daemon option.
