### PR TITLE
Added the registry_mirror daemon argument

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -167,6 +167,8 @@ default['docker']['tlskey'] = nil
 default['docker']['tlsverify'] = nil
 default['docker']['tmpdir'] = nil
 
+default['docker']['registry_mirror'] = nil
+
 # LWRP attributes
 
 default['docker']['docker_daemon_timeout'] = 10

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -98,7 +98,8 @@ EOH
         'tlscacert' => node['docker']['tlscacert'],
         'tlscert' => node['docker']['tlscert'],
         'tlskey' => node['docker']['tlskey'],
-        'tlsverify' => node['docker']['tlsverify']
+        'tlsverify' => node['docker']['tlsverify'],
+        'registry-mirror' => Array(node['docker']['registry_mirror'])
       )
       daemon_options += " #{node['docker']['options']}" if node['docker']['options']
       daemon_options


### PR DESCRIPTION
I know this can be configured using the fallback `options` attribute, but it can be useful to have a specific attribute so you can use the environments/roles to set defaults, for example.
