### PR TITLE
Deprecate the 'restart' daemon option (obsolete since docker 1.2.0).

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ no_proxy | NO_PROXY environment variable | String | nil
 options | Additional options to pass to docker. These could be flags like "-api-enable-cors". | String | nil
 pidfile | Path to use for daemon PID file | String | nil (implicitly /var/run/docker.pid)
 ramdisk | Set DOCKER_RAMDISK when using RAM disk | TrueClass or FalseClass | false
-restart | Restart containers on boot | TrueClass or FalseClass | auto-detected (see attributes/default.rb)
+restart (*DEPRECATED*) | Restart containers on boot | TrueClass or FalseClass | auto-detected (see attributes/default.rb)
 selinux_enabled | Enable SELinux | TrueClass or FalseClass | nil
 storage_driver | Storage driver for docker | String | nil
 storage_opt | Storage driver options | String, Array | nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -186,4 +186,5 @@ default['docker']['registry_cmd_timeout'] = 60
 
 # Other attributes
 
+# DEPRECATED: will be removed in chef-docker 1.0
 default['docker']['restart'] = false if node['docker']['container_init_type']

--- a/spec/systemd_spec.rb
+++ b/spec/systemd_spec.rb
@@ -87,6 +87,7 @@ describe 'docker::systemd' do
     end
   end
 
+  # DEPRECATED: will be removed in chef-docker 1.0
   context 'when container_init_type is set' do
     let(:chef_run) do
       runner = ChefSpec::Runner.new

--- a/spec/sysv_spec.rb
+++ b/spec/sysv_spec.rb
@@ -98,6 +98,7 @@ describe 'docker::sysv' do
     end
   end
 
+  # DEPRECATED: will be removed in chef-docker 1.0
   context 'when container_init_type is set' do
     let(:chef_run) do
       runner = ChefSpec::Runner.new

--- a/spec/upstart_spec.rb
+++ b/spec/upstart_spec.rb
@@ -99,6 +99,7 @@ describe 'docker::upstart' do
     end
   end
 
+  # DEPRECATED: will be removed in chef-docker 1.0
   context 'when container_init_type is set' do
     let(:chef_run) do
       runner = ChefSpec::Runner.new


### PR DESCRIPTION
I just found out that the `--restart` daemon option has been obsoleted in [docker 1.2.0](http://blog.docker.com/2014/08/announcing-docker-1-2-0/). The option is no longer documented and even if its presence won't prevent the docker daemon to start, it will be ignored. The container restart is now done with explicit [restart policies](http://docs.docker.com/reference/commandline/cli/#restart-policies).

This PR deprecates the attribute (which we can keep for now, no harm); we should remove it with version 1.0.0 of the cookbook.
