### PR TITLE
Upstart: install inotify-tools only once (avoid CHEF-3694 warning).

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -487,9 +487,15 @@ end
 
 def service_create_upstart
   # The upstart init script requires inotifywait, which is in inotify-tools
-  package 'inotify-tools' do
-    action :nothing
-  end.run_action(:install)
+  # For clarity, install the package here but do it only once (no CHEF-3694).
+  begin
+    run_context.resource_collection.find(:package => 'inotify-tools')
+    # If we get here then we already installed the resource the first time.
+  rescue Chef::Exceptions::ResourceNotFound
+    package('inotify-tools') do
+      action :nothing
+    end.run_action(:install)
+  end
 
   template "/etc/init/#{service_name}.conf" do
     source service_template


### PR DESCRIPTION
This PR avoids the resource-cloning ([CHEF-3694](https://tickets.opscode.com/browse/CHEF-3694)) warning that triggers when deploying more than one container as upstart services.

Symptoms of the problem:

```
==> default: [2014-11-18T08:35:44+00:00] WARN: Cloning resource attributes for package[inotify-tools] from prior resource (CHEF-3694)
==> default: [2014-11-18T08:35:44+00:00] WARN: Previous package[inotify-tools]: /tmp/vagrant-chef-3/chef-solo-1/cookbooks/docker/providers/container.rb:490:in `service_create_upstart'
==> default: [2014-11-18T08:35:44+00:00] WARN: Current  package[inotify-tools]: /tmp/vagrant-chef-3/chef-solo-1/cookbooks/docker/providers/container.rb:490:in `service_create_upstart'
```

The reason is that the generated upstart service depends on the `inotify-tools` package (which must be present at compile-time since the docker_cmd commands run at compile-time); since this package is installed as a technical detail, I think that it should indeed be installed from within the docker_container LWRP as today and not in an external recipe.
