### PR TITLE
Fixed dead service containers not being restarted on docker_container :run

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -609,6 +609,7 @@ def start
   )
   if service?
     service_create
+    service_run
   else
     docker_cmd!("start #{start_args} #{current_resource.id}")
   end


### PR DESCRIPTION
I just stumbled on @jochenseeber 's #235 issue when investigating why some containers were not being restarted after running chef-client on my production server.

In short, when a container:
1. is deployed as a service (upstart or other) and
2. is not running (eg. because I have restarted the docker daemon without having a container restart policy set, or because I have previously stopped the service)

Then the next chef-run will leave my container down without trying to restart it.

This modest PR should easily fix the issue.
