### PR TITLE
Made docker_container action :remove remove the actual upstart service file

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -556,7 +556,7 @@ end
 def service_remove_upstart
   service_stop_and_disable
 
-  file "/etc/init/#{service_name}" do
+  file "/etc/init/#{service_name}.conf" do
     action :delete
   end
 end


### PR DESCRIPTION
This PR fixes the typo that prevented docker_container action :remove from removing the upstart service file associated with the container.
