### PR TITLE
Add support for --exec-opt to docker daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tmp/
 *.sublime-workspace
 *.un~
 .idea/
+*.iml
 
 # OS files
 .DS_Store

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -23,6 +23,7 @@ module DockerCookbook
     property :dns, ArrayType
     property :dns_search, [Array, nil]
     property :exec_driver, ['native', 'lxc', nil]
+    property :exec_opts, ArrayType
     property :fixed_cidr, [String, nil]
     property :fixed_cidr_v6, [String, nil]
     property :group, [String, nil]

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -133,6 +133,7 @@ module DockerCookbook
         dns.each { |dns| opts << "--dns=#{dns}" } if dns
         dns_search.each { |dns| opts << "--dns-search=#{dns}" } if dns_search
         opts << "--exec-driver=#{exec_driver}" if exec_driver
+        exec_opts.each { |exec_opt| opts << "--exec-opt=#{exec_opt}" } if exec_opts
         opts << "--fixed-cidr=#{fixed_cidr}" if fixed_cidr
         opts << "--fixed-cidr-v6=#{fixed_cidr_v6}" if fixed_cidr_v6
         opts << "--group=#{group}" if group


### PR DESCRIPTION
Add support for --exec-opt to docker daemon.
This seems to be needed to workaround docker/docker#17653 on Centos 7.