### PR TITLE
Rename cluster-opts to cluster-opt

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -128,7 +128,7 @@ module DockerCookbook
         opts << '--debug' if debug
         opts << "--cluster-advertise=#{cluster_advertise}" if cluster_advertise
         opts << "--cluster-store=#{cluster_store}" if cluster_store
-        cluster_store_opts.each { |store_opt| opts << "--cluster-store-opts=#{store_opt}" } if cluster_store_opts
+        cluster_store_opts.each { |store_opt| opts << "--cluster-store-opt #{store_opt}" } if cluster_store_opts
         default_ulimit.each { |u| opts << "--default-ulimit=#{u}" } if default_ulimit
         dns.each { |dns| opts << "--dns=#{dns}" } if dns
         dns_search.each { |dns| opts << "--dns-search=#{dns}" } if dns_search

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -128,7 +128,7 @@ module DockerCookbook
         opts << '--debug' if debug
         opts << "--cluster-advertise=#{cluster_advertise}" if cluster_advertise
         opts << "--cluster-store=#{cluster_store}" if cluster_store
-        cluster_store_opts.each { |store_opt| opts << "--cluster-store-opt #{store_opt}" } if cluster_store_opts
+        cluster_store_opts.each { |store_opt| opts << "--cluster-store-opt=#{store_opt}" } if cluster_store_opts
         default_ulimit.each { |u| opts << "--default-ulimit=#{u}" } if default_ulimit
         dns.each { |dns| opts << "--dns=#{dns}" } if dns
         dns_search.each { |dns| opts << "--dns-search=#{dns}" } if dns_search


### PR DESCRIPTION
Noticed that the naming of the `--cluster-store-opt` was wrong, a `s` to much.

From `docker daemon --help`
```
--cluster-store-opt=map[]            Set cluster store options
```