### PR TITLE
excon opts should be symbols

### DIFF
--- a/libraries/helpers_base.rb
+++ b/libraries/helpers_base.rb
@@ -38,8 +38,8 @@ module DockerCookbook
       def connection
         @connection ||= begin
                           opts = {}
-                          opts['read_timeout'] = read_timeout if read_timeout
-                          opts['write_timeout'] = write_timeout if write_timeout
+                          opts[:read_timeout] = read_timeout if read_timeout
+                          opts[:write_timeout] = write_timeout if write_timeout
 
                           if host =~ /^tcp:/
                             opts[:scheme] = 'https' if tls || !tls_verify.nil?


### PR DESCRIPTION
somewhere between switching to using our own connection and the latest docker-api gem, this is simply resolved by passing symbols instead of strings. timeout test-kitchen passes with flying colors.

the more you know :stars: 

resolves #458