### PR TITLE
Support linuxmint 17.*, its based on trusty

### DIFF
--- a/libraries/helpers_installation_package.rb
+++ b/libraries/helpers_installation_package.rb
@@ -28,6 +28,7 @@ module DockerCookbook
 
       def trusty?
         return true if node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
+        return true if node['platform'] == 'linuxmint' && node['platform_version'] =~ /^17\.[0-9]$/
         false
       end
 


### PR DESCRIPTION
Linuxmint is used on many Linux desktop installations. Linux Mint 17.X is based on the current Ubuntu LTS 14.04 trusty.