### PR TITLE
Typo fix: it should be pidfile property

### DIFF
--- a/libraries/docker_service_manager_execute.rb
+++ b/libraries/docker_service_manager_execute.rb
@@ -54,7 +54,7 @@ module DockerCookbook
 
     action :stop do
       execute "stop docker #{name}" do
-        command "kill `cat #{pid_file}`"
+        command "kill `cat #{pidfile}`"
         only_if "#{docker_cmd} ps | head -n 1 | grep ^CONTAINER"
       end
     end


### PR DESCRIPTION
Otherwise you might get `NoMethodError: undefined method `pid_file' for Chef::Resource::Execute`