### PR TITLE
Allow distributed gems to be activated normally via Ruby

### DIFF
--- a/libraries/_autoload.rb
+++ b/libraries/_autoload.rb
@@ -1,2 +1,6 @@
-$LOAD_PATH.push *Dir[File.expand_path('../../files/default/vendor/gems/**/lib', __FILE__)]
+# Set up rubygems to activate any gems we find herein.
+ENV['GEM_PATH'] = ([ File.expand_path('../../files/default/vendor', __FILE__) ] + Gem.path).join(Gem.path_separator)
+Gem.paths = ENV
+gem 'docker-api', '~> 1.24'
+
 $LOAD_PATH.unshift *Dir[File.expand_path('..', __FILE__)]


### PR DESCRIPTION
Handles these cases better:
1. If docker-api is not loaded or installed on the system, the cookbook’s version will be used.
2. If docker-api is not loaded, and docker-api 1.30 is installed on the system, that will be loaded instead.
3. If docker-api is not loaded, and docker-api 1.23 is installed on the system, the cookbook's version (1.24) will be used.
4. If someone else loaded docker-api 1.23 already, we fail to load the cookbook since it's not an acceptable version.
5. If someone else loaded docker-api 1.30 already, we don't load anything because it is an acceptable version.