### PR TITLE
changed docker_service.bridge validation to be String

### DIFF
--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -20,7 +20,7 @@ module DockerCookbook
     property :instance, String, name_property: true, required: true, desired_state: false
     property :auto_restart, Boolean, default: false
     property :api_cors_header, [String, nil]
-    property :bridge, [IPV4_ADDR, IPV6_ADDR, nil]
+    property :bridge, [String, nil]
     property :bip, [IPV4_ADDR, IPV4_CIDR, IPV6_ADDR, IPV6_CIDR, nil]
     property :cluster_store, [String, nil]
     property :cluster_advertise, [String, nil]


### PR DESCRIPTION
fixing #593: changed validation of docker_service's bridge attribute to String (as this is not an ip, but a existing network bridge name)