### PR TITLE
Fix #598. return value check for docker-wait-ready with systemd

### DIFF
--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -16,6 +16,8 @@ module DockerCookbook
       node['platform_version'].to_f >= 15.04
     end
 
+    property :service_timeout, Integer, default: 20
+
     action :start do
       # Needed for Debian / Ubuntu
       directory '/usr/libexec' do
@@ -32,7 +34,10 @@ module DockerCookbook
         owner 'root'
         group 'root'
         mode '0755'
-        variables(docker_cmd: docker_cmd)
+        variables(
+          docker_cmd: docker_cmd,
+          service_timeout: service_timeout
+        )
         cookbook 'docker'
         action :create
       end

--- a/templates/default/systemd/docker-wait-ready.erb
+++ b/templates/default/systemd/docker-wait-ready.erb
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 i=0
-while [ $i -lt 40 ]; do
+while [ $i -lt <%= @service_timeout * 2 %> ]; do
   ((i++))
   <%= @docker_cmd %> ps | head -n 1 | grep ^CONTAINER > /dev/null 2>&1
   [ $? -eq 0 ] && break
   sleep 0.5
 done
-[ $i -eq 20 ] && exit 1
+[ $i -eq <%= @service_timeout * 2 %> ] && exit 1
 exit 0

--- a/templates/default/systemd/docker-wait-ready.erb
+++ b/templates/default/systemd/docker-wait-ready.erb
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 i=0
 while [ $i -lt <%= @service_timeout * 2 %> ]; do
-  ((i++))
   <%= @docker_cmd %> ps | head -n 1 | grep ^CONTAINER > /dev/null 2>&1
   [ $? -eq 0 ] && break
+  ((i++))
   sleep 0.5
 done
 [ $i -eq <%= @service_timeout * 2 %> ] && exit 1


### PR DESCRIPTION
**VERSION**
2.4.0
Commit 052f747e8c0f69b177137d698226228f2885d093

**REPRODUCE**
( Edited after @bflad 's comment)
Use this modified docker-wait-ready.erb file to test failure
```
#!/usr/bin/env bash
i=0
while [ $i -lt <%= @service_timeout * 2 %> ]; do
  <%= @docker_cmd %> ps | head -n 1 | grep ^failureCONTAINER > /dev/null 2>&1
  [ $? -eq 0 ] && break
  ((i++))
  sleep 0.5
done
[ $i -eq <%= @service_timeout * 2 %> ] && exit 1
exit 0
```