### PR TITLE
Daemon execution fix for last iteration. Fixes #600

### DIFF
--- a/libraries/docker_service_manager_execute.rb
+++ b/libraries/docker_service_manager_execute.rb
@@ -38,11 +38,11 @@ module DockerCookbook
         code <<-EOF
             timeout=0
             while [ $timeout -lt 20 ];  do
-              ((timeout++))
               #{docker_cmd} ps | head -n 1 | grep ^CONTAINER
                 if [ $? -eq 0 ]; then
                   break
                 fi
+              ((timeout++))
                sleep 1
             done
             [[ $timeout -eq 20 ]] && exit 1


### PR DESCRIPTION
**VERSION**
2.4.0
Commit 052f747e8c0f69b177137d698226228f2885d093

**FIXES**
Last iteration suceedd status.

**REPRODUCE**

This is a modified version of the script that waits 5 seconds instead of 20, and succeeds only in the last iteration.

```
timeout=0
while [ $timeout -lt 5 ];  do
  docker ps | head -n 1 | grep ^CONTAINER && [[ $timeout -eq 4 ]]
  if [ $? -eq 0 ]; then
    break
  fi
  ((timeout++))
   sleep 1
done
[[ $timeout -eq 5 ]] && exit 1
exit 0
```
Exit code must be 0 if docker daemon is running and configured for default socket file.

Current behaviour for that same simulation is as follows
```
timeout=0
while [ $timeout -lt 5 ];  do
  ((timeout++))
  docker ps | head -n 1 | grep ^CONTAINER && [[ $timeout -eq 5 ]]
  if [ $? -eq 0 ]; then
    break
  fi
   sleep 1
done
[[ $timeout -eq 5 ]] && exit 1
exit 0
```
Last iteration succeeds but exit code is 1