### PR TITLE
setting container property defaults to match docker cli

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -32,56 +32,56 @@ module DockerCookbook
     property :repo, String, default: lazy { container_name }
     property :tag, String, default: 'latest'
     property :command, ShellCommand
-    property :attach_stderr, Boolean, desired_state: false
-    property :attach_stdin, Boolean, desired_state: false
-    property :attach_stdout, Boolean, desired_state: false
+    property :attach_stderr, Boolean, default: false, desired_state: false
+    property :attach_stdin, Boolean, default: false, desired_state: false
+    property :attach_stdout, Boolean, default: false, desired_state: false
     property :autoremove, Boolean, desired_state: false
-    property :cap_add, NonEmptyArray
-    property :cap_drop, NonEmptyArray
+    property :cap_add, NonEmptyArray, default: nil
+    property :cap_drop, NonEmptyArray, default: nil
     property :cgroup_parent, String, default: ''
     property :cpu_shares, [Fixnum, nil], default: 0
     property :cpuset_cpus, String, default: ''
     property :detach, Boolean, default: true, desired_state: false
-    property :devices, ArrayType
-    property :dns, NonEmptyArray
-    property :dns_search, ArrayType
+    property :devices, Array, default: []
+    property :dns, Array, default: []
+    property :dns_search, Array, default: []
     property :domain_name, String, default: ''
-    property :entrypoint, ShellCommand
-    property :env, UnorderedArrayType
-    property :extra_hosts, NonEmptyArray
+    property :entrypoint, ShellCommand, default: nil
+    property :env, UnorderedArrayType, default: []
+    property :extra_hosts, NonEmptyArray, default: nil
     property :exposed_ports, PartialHashType
     property :force, Boolean, desired_state: false
     property :host, [String], default: lazy { default_host }, desired_state: false
     property :hostname, String
-    property :ipc_mode, String
-    property :labels, [String, Array, Hash], coerce: proc { |v| coerce_labels(v) }
-    property :links, [Array, nil], coerce: proc { |v| coerce_links(v) }
+    property :ipc_mode, String, default: ''
+    property :labels, [String, Array, Hash], default: {}, coerce: proc { |v| coerce_labels(v) }
+    property :links, [Array, nil], default: nil, coerce: proc { |v| coerce_links(v) }
     property :log_driver, %w( json-file syslog journald gelf fluentd none ), default: 'json-file'
     property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }
     property :mac_address, String
     property :memory, Fixnum, default: 0
-    property :memory_swap, Fixnum, default: -1
+    property :memory_swap, Fixnum, default: 0
     property :network_disabled, Boolean, default: false
     property :network_mode, [String, nil], default: lazy { default_network_mode }
-    property :open_stdin, Boolean, desired_state: false
+    property :open_stdin, Boolean, default: false, desired_state: false
     property :outfile, [String, nil], default: nil
-    property :port_bindings, PartialHashType
-    property :pid_mode, String
-    property :privileged, Boolean
-    property :publish_all_ports, Boolean
+    property :port_bindings, PartialHashType, default: {}
+    property :pid_mode, String, default: ''
+    property :privileged, Boolean, default: false
+    property :publish_all_ports, Boolean, default: false
     property :remove_volumes, Boolean
     property :restart_maximum_retry_count, Fixnum, default: 0
     property :restart_policy, String, default: 'no'
-    property :security_opts, [String, Array], default: lazy { [''] }
-    property :signal, String, default: 'SIGKILL'
-    property :stdin_once, Boolean, desired_state: false
+    property :security_opts, [String, ArrayType], default: nil
+    property :signal, String, default: 'SIGTERM'
+    property :stdin_once, Boolean, default: false, desired_state: false
     property :timeout, [Fixnum, nil], desired_state: false
-    property :tty, Boolean
-    property :ulimits, [Array, nil], coerce: proc { |v| coerce_ulimits(v) }
+    property :tty, Boolean, default: false
+    property :ulimits, [Array, nil], default: nil, coerce: proc { |v| coerce_ulimits(v) }
     property :user, String, default: ''
-    property :volumes, PartialHashType, coerce: proc { |v| coerce_volumes(v) }
-    property :volumes_from, ArrayType
-    property :working_dir, [String, nil]
+    property :volumes, PartialHashType, default: {}, coerce: proc { |v| coerce_volumes(v) }
+    property :volumes_from, ArrayType, default: nil
+    property :working_dir, [String, nil], default: ''
 
     # Used to store the bind property since binds is an alias to volumes
     property :volumes_binds, Array, desired_state: false
@@ -276,7 +276,6 @@ module DockerCookbook
               'VolumesFrom'     => volumes_from
             }
           }
-          compact!(config)
           Docker::Container.create(config, connection)
         end
       end

--- a/libraries/helpers_base.rb
+++ b/libraries/helpers_base.rb
@@ -96,14 +96,6 @@ module DockerCookbook
           "#{ENV['DOCKER_CERT_PATH']}/key.pem"
         end
       end
-
-      # recursively remove nil values from a hash
-      def compact!(v)
-        v.reject! do |_, value|
-          compact!(value) if value.is_a?(Hash)
-          value.nil?
-        end
-      end
     end
   end
 end

--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -49,8 +49,9 @@ module DockerCookbook
             parts = x.split(':')
             b << x if parts.length > 1
           end
-          volumes_binds b unless b.empty?
-          return nil if v.empty?
+          b = nil if b.empty?
+          volumes_binds b
+          return DockerBase::PartialHash.new if v.empty?
           v.each_with_object(DockerBase::PartialHash.new) { |volume, h| h[volume] = {} }
         end
       end

--- a/spec/docker_test/container_spec.rb
+++ b/spec/docker_test/container_spec.rb
@@ -33,13 +33,13 @@ describe 'docker_test::container' do
         domain_name: '',
         log_driver: 'json-file',
         memory: 0,
-        memory_swap: -1,
+        memory_swap: 0,
         network_disabled: false,
         outfile: nil,
         restart_maximum_retry_count: 0,
         restart_policy: 'no',
-        security_opts: [''],
-        signal: 'SIGKILL',
+        security_opts: nil,
+        signal: 'SIGTERM',
         user: ''
       )
     end
@@ -112,7 +112,7 @@ describe 'docker_test::container' do
   context 'testing action :kill' do
     it 'run execute[bill]' do
       expect(chef_run).to run_execute('bill').with(
-        command: 'docker run --name bill -d busybox nc -ll -p 187 -e /bin/cat'
+        command: 'docker run --name bill -d busybox sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"'
       )
     end
 

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -90,7 +90,7 @@ end
 
 # start a container to be killed
 execute 'bill' do
-  command 'docker run --name bill -d busybox nc -ll -p 187 -e /bin/cat'
+  command 'docker run --name bill -d busybox sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"'
   not_if "[ ! -z `docker ps -qaf 'name=bill$'` ]"
   action :run
 end

--- a/test/integration/resources-191/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-191/serverspec/assert_functioning_spec.rb
@@ -844,15 +844,14 @@ describe command("docker inspect --format '{{ .HostConfig.IpcMode }}' ipc_mode")
   its(:stdout) { eq 'host' }
 end
 
-# except for a few, containers shouldnt be killed
+# containers shouldnt be killed, validating only one was force killed
 
 describe command("docker ps -qaf 'exited=137' | wc -l") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/2/) }
+  its(:stdout) { should match(/1/) }
 end
 
 describe command("docker ps -af 'exited=137'") do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/kill_after/) }
-  its(:stdout) { should match(/bill/) }
 end


### PR DESCRIPTION
i think this should help resolve #597. compact was clobbering empty settings, which apparently can be important in certain cases.