### PR TITLE
Fix coerce_volumes in case current value is a Chef::Node::ImmutableArray

### DIFF
--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -44,7 +44,7 @@ module DockerCookbook
           DockerBase::PartialHash[v]
         else
           b = []
-          v = Array(v)
+          v = Array(v).to_a # in case v.is_A?(Chef::Node::ImmutableArray)
           v.delete_if do |x|
             parts = x.split(':')
             b << x if parts.length > 1


### PR DESCRIPTION
This PR fixes the problem I encountered with the recently released version 2.4.3 where my chef run would fail with the following exception:

```
    Chef::Exceptions::ImmutableAttributeModification
    ------------------------------------------------
    Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'
    
    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/docker/libraries/helpers_container.rb:48:in `coerce_volumes'
    ...
```

This would trigger for docker_container resource where the volume/binds declaration is using the Array form (eg. `mycontainer.volume = ['/hostpath:/containerpath']`).