### PR TITLE
Use Gem::Version to handle semantic verisoning and be compatible for ≥ 1.10

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -92,7 +92,7 @@ module DockerCookbook
       end
 
       def docker_daemon_arg
-        if docker_major_version.to_f < 1.8
+        if Gem::Version.new(docker_major_version) < Gem::Version.new("1.8")
           '-d'
         else
           'daemon'


### PR DESCRIPTION
The current 'master' code is not working for docker >= 1.10

Explanation:

``` ruby
"1.10".to_f < 1.8
```

It results in running `docker -d` instead of `docker daemon`

This patch fix that by using `Gem::Version` class which handle pretty well versions, and even, pre-version.