### PR TITLE
Add host back to docker network

### DIFF
--- a/libraries/docker_network.rb
+++ b/libraries/docker_network.rb
@@ -6,6 +6,7 @@ module DockerCookbook
     resource_name :docker_network
 
     property :network_name, String, name_property: true
+    property :host, [String, nil], default: lazy { default_host }
     property :id, String
     property :driver, [String, nil]
     property :driver_opts, [String, Array, nil]


### PR DESCRIPTION
It seems that `host` property got removed from `Docker::Network` ( chef-cookbooks/docker@b743e8b609c9fd809399e19d2f4e164a24226e22 ). This makes it impossible to make a connection to the docker daemon ( https://github.com/chef-cookbooks/docker/blob/master/libraries/helpers_base.rb#L50 ). This PR will add `host` back so `docker_network` starts working again.

PS. I have tests for docker network on their way. DS.