### PR TITLE
Set default docker_container.exposed_port to empty Hash

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -49,7 +49,7 @@ module DockerCookbook
     property :entrypoint, ShellCommand
     property :env, UnorderedArrayType, default: []
     property :extra_hosts, NonEmptyArray
-    property :exposed_ports, PartialHashType
+    property :exposed_ports, PartialHashType, default: {}
     property :force, Boolean, desired_state: false
     property :host, [String, nil], default: lazy { default_host }, desired_state: false
     property :hostname, String


### PR DESCRIPTION
Isolated this bit from issue #597 and proposing a PR to fix the 'exposed_ports' case.

Currently using version 2.4.11 of this cookbook.

I have a docker_container on which redeploys at each chef-run. This container is using the `gliderlabs/registrator:v6` image, an image which does NOT expose any port all all, as shown by the following `docker inspect` commands:

```sh
# This image exposes no ports
$ docker inspect -f '{{ .Config.ExposedPorts }}' gliderlabs/registrator:v6
map[]
# Compare with a typical image which exposes ports
$ docker inspect -f '{{ .Config.ExposedPorts }}' phusion/passenger-ruby22:0.9.17
map[443/tcp:{} 80/tcp:{}]
```

At each chef-run, that docker_container is redeployed with the following trace:

    * docker_container[registrator] action run
      - stopping registrator 
      - deleting registrator
      - update registrator
      -   set exposed_ports to {} (was nil)
      - starting registrator

I believe that the redeploy is due to an incorrect default value for the docker_container exposed_port attribute. Since the API does not list the attribute in its response, the default value (`nil`) from the docker_container resource is assumed for the current resource while the value on the new resource is an empty Hash. The values differ, hence redeployment.

This PR sets the default value for exposed ports to an empty Hash. I ran out of time to write a dedicated test but I can confirm that the fix works on our servers and that the `resources-191-ubuntu-1504` kitchen suite still passes.