### PR TITLE
dropping support for centos 6 in test-kitchen

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -16,18 +16,6 @@ verifier:
   name: inspec
 
 platforms:
-- name: centos-6.5
-  driver_plugin: digitalocean
-  driver_config:
-    size: 2gb
-    image: centos-6-5-x64
-    region: <%= ENV['DIGITALOCEAN_REGION'] %>
-    ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
-  transport:
-    ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
-  run_list:
-  - recipe[yum-docker]
-
 - name: centos-7.0
   driver_plugin: digitalocean
   driver_config:
@@ -200,7 +188,6 @@ suites:
 
 # - name: installation_package-171
 #   includes: [
-#     'centos-6.5',
 #     'ubuntu-12.04',
 #     'ubuntu-14.04',
 #     'ubuntu-15.10'
@@ -277,7 +264,6 @@ suites:
 ##################################
 - name: service-sysvinit
   includes: [
-    'centos-6.5',
     'ubuntu-12.04'
   ]
   run_list:
@@ -285,7 +271,6 @@ suites:
 
 - name: service-sysvinit-multi
   includes: [
-    'centos-6.5',
     'ubuntu-12.04'
   ]
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,13 +17,6 @@ verifier:
   name: inspec
 
 platforms:
-- name: centos-6.5
-  driver_config:
-    box: opscode-centos-6.5
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-  run_list:
-  - recipe[yum-docker]
-
 - name: centos-7.1
   driver_config:
     box: opscode-centos-7.1
@@ -151,7 +144,6 @@ suites:
 
 - name: installation_package-171
   includes: [
-    'centos-6.5',
     'ubuntu-12.04',
     'ubuntu-14.04',
     'ubuntu-15.04'
@@ -212,7 +204,6 @@ suites:
 ##################################
 - name: service-sysvinit
   includes: [
-    'centos-6.5',
     'ubuntu-12.04'
   ]
   run_list:


### PR DESCRIPTION
removing references for my sanity that centos 6 no longer is supported.

https://github.com/docker/docker/issues/14174#issuecomment-118169576