### PR TITLE
Add ChefSpec.define_matcher for each docker resource

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -2,6 +2,8 @@ if defined?(ChefSpec)
   #####################
   # docker_installation
   #####################
+  ChefSpec.define_matcher :docker_installation
+
   def create_docker_installation(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_installation, :create, resource_name)
   end
@@ -37,6 +39,8 @@ if defined?(ChefSpec)
   ################
   # docker_service
   ################
+  ChefSpec.define_matcher :docker_service
+
   def create_docker_service(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_service, :create, resource_name)
   end
@@ -60,6 +64,7 @@ if defined?(ChefSpec)
   ########################
   # docker_service_manager
   ########################
+  ChefSpec.define_matcher :docker_service_manager
 
   def create_docker_service_manager(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_service_manager, :create, resource_name)
@@ -164,6 +169,8 @@ if defined?(ChefSpec)
   ##############
   # docker_image
   ##############
+  ChefSpec.define_matcher :docker_image
+
   def build_docker_image(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_image, :build, resource_name)
   end
@@ -199,6 +206,7 @@ if defined?(ChefSpec)
   ##################
   # docker_container
   ##################
+  ChefSpec.define_matcher :docker_container
 
   def create_docker_container(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_container, :create, resource_name)
@@ -263,6 +271,7 @@ if defined?(ChefSpec)
   ##############
   # docker_tag
   ##############
+  ChefSpec.define_matcher :docker_tag
 
   def tag_docker_tag(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_tag, :tag, resource_name)
@@ -271,6 +280,7 @@ if defined?(ChefSpec)
   #################
   # docker_registry
   #################
+  ChefSpec.define_matcher :docker_registry
 
   def login_docker_registry(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry, :login, resource_name)
@@ -279,6 +289,7 @@ if defined?(ChefSpec)
   ################
   # docker_network
   ################
+  ChefSpec.define_matcher :docker_network
 
   def create_docker_network(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_network, :create, resource_name)
@@ -299,6 +310,7 @@ if defined?(ChefSpec)
   ###############
   # docker_volume
   ###############
+  ChefSpec.define_matcher :docker_volume
 
   def create_docker_volume(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_volume, :create, resource_name)


### PR DESCRIPTION
This PR adds `ChefSpec.define_matcher` for each docker resource.

Currently in ChefSpec if I try to do something like

```ruby
        resource = chef_run.docker_container('default')
        expect(resource.env).to eq 'TEST=123'
```

I get

```
     Failure/Error: resource = chef_run.docker_container('default')

     NoMethodError:
       undefined method `docker_container' for #<ChefSpec::ServerRunner:0x007faf52ece3f8>
```