### PR TITLE
Fix chef warning

### DIFF
--- a/libraries/docker_service.rb
+++ b/libraries/docker_service.rb
@@ -25,7 +25,7 @@ module DockerCookbook
 
     # binary and package
     property :version, String, desired_state: false
-    property :package_options, String, default: nil, desired_state: false
+    property :package_options, [ String, nil ], default: nil, desired_state: false
 
     ################
     # Helper Methods


### PR DESCRIPTION
WARN: Default value nil is invalid for property package_options of resource docker_installation_package. Possible fixes: 
1. Remove 'default: nil' if nil means 'undefined'. 
2. Set a valid default value if there is a reasonable one. 
3. Allow nil as a valid value of your property (for example, 'property :package_options, [ String, nil ], default: nil'). 

Error: Property package_options must be one of: String!  You passed nil. at [...]/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef.rb:20:in `log_deprecation'