### PR TITLE
Added no_proxy to default docker template

### DIFF
--- a/templates/default/default/docker.erb
+++ b/templates/default/default/docker.erb
@@ -14,6 +14,10 @@ export http_proxy="<%= @config.http_proxy %>"
 export https_proxy="<%= @config.https_proxy %>"
 <% end %>
 
+<% if @config.no_proxy %>
+export no_proxy="<%= @config.no_proxy %>"
+<% end %>
+
 # This is also a handy place to tweak where Docker's temporary files go.
 <% if @config.tmpdir %>
 export TMPDIR="<%= @config.tmpdir  %>"


### PR DESCRIPTION
The template for /etc/default/docker was missing the option for rendering the no_proxy environment variable.  I've added the option after the http_proxy and https_proxy options.