### PR TITLE
Resolve restarting container races

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -299,11 +299,13 @@ module DockerCookbook
       kill_after_str = " (will kill after #{kill_after}s)" if kill_after != -1
       converge_by "stopping #{container_name} #{kill_after_str}" do
         begin
-          with_retries { container.stop!('timeout' => kill_after) }
+          with_retries do
+            container.stop!('timeout' => kill_after)
+            wait_running_state(false)
+          end
         rescue Docker::Error::TimeoutError
           raise Docker::Error::TimeoutError, "Container raiseed to stop, consider adding kill_after to the container #{container_name}"
         end
-        wait_running_state(false)
       end
     end
 

--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -69,13 +69,16 @@ module DockerCookbook
       end
 
       def state
-        container ? container.info['State'] : {}
+        # Always return the latest state, see #510
+        return Docker::Container.get(container_name, {}, connection).info['State']
+      rescue
+        return {}
       end
 
       def wait_running_state(v)
         i = 0
         tries = 20
-        until state['Running'] == v || state['FinishedAt'] != '0001-01-01T00:00:00Z'
+        until state['Running'] == v
           i += 1
           break if i == tries
           sleep 1

--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -76,13 +76,16 @@ module DockerCookbook
       end
 
       def wait_running_state(v)
-        i = 0
         tries = 20
-        until state['Running'] == v
-          i += 1
-          break if i == tries
+        tries.times do
+          return if state['Running'] == v
           sleep 1
         end
+        return if state['Running'] == v
+
+        # Container failed to reach correct state: Throw an error
+        desired_state_str = v ? 'running' : 'not running'
+        raise Docker::Error::TimeoutError, "Container #{container_name} failed to change to #{desired_state_str} state after #{tries} seconds"
       end
 
       def port(v = nil)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Sean OMeara'
 maintainer_email 'sean@chef.io'
 license 'Apache 2.0'
 description 'Provides docker_service, docker_image, and docker_container resources'
-version '2.5.8'
+version '2.5.9'
 
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Sean OMeara'
 maintainer_email 'sean@chef.io'
 license 'Apache 2.0'
 description 'Provides docker_service, docker_image, and docker_container resources'
-version '2.5.9'
+version '2.5.8'
 
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'


### PR DESCRIPTION
This PR:
- Ensures that wait_running_state uses the current state of the container, not a stored value, as discussed in #510 
- Throws an exception if wait_running_state times out.  This is used to allow retries for the second race mentioned in #679 and should cause test errors if the operation is timing out.
- Retries the stop operation if the container fails to stop in wait_running_state.  This resolves a difficult to reproduce corner case race mentioned in #679.
