### PR TITLE
Add support for docker_container image property with custom repository port.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 group :unit do
   gem 'berkshelf',  '~> 4.0'
   gem 'chefspec',   '~> 4.5'
+  gem 'rspec-its'
 end
 
 group :kitchen_common do

--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -169,8 +169,8 @@ module DockerCookbook
         def_logcfg
       end
 
-      # TODO: test image property in serverspec and kitchen
-      # TODO: test this logic with rspec
+      # TODO: test image property in serverspec and kitchen, not only in rspec
+      # for full specs of image parsing, see spec/helpers_container_spec.rb
       #
       # If you say:    `repo 'blah'`
       # Image will be: `blah:latest`
@@ -186,9 +186,36 @@ module DockerCookbook
       # Repo will be:  `blah`
       # Tag will be:   `3.1`
       #
+      # If you say:    `image 'repo/blah'`
+      # Repo will be:  `repo/blah`
+      # Tag will be:   `latest`
+      #
+      # If you say:    `image 'repo/blah:3.1'`
+      # Repo will be:  `repo/blah`
+      # Tag will be:   `3.1`
+      #
+      # If you say:    `image 'repo:1337/blah'`
+      # Repo will be:  `repo:1337/blah`
+      # Tag will be:   `latest'
+      #
+      # If you say:    `image 'repo:1337/blah:3.1'`
+      # Repo will be:  `repo:1337/blah`
+      # Tag will be:   `3.1`
+      #
       def image(image = nil)
         if image
-          r, t = image.split(':', 2)
+          if image.include?('/')
+            # pathological case, a ':' may be present which starts the 'port'
+            # part of the image name and not a tag. example: 'host:1337/blah'
+            # fortunately, tags are only found in the 'basename' part of image
+            # so we can split on '/' and rebuild once the tag has been parsed.
+            dirname, _, basename = image.rpartition('/')
+            r, t = basename.split(':', 2)
+            r = [dirname, r].join('/')
+          else
+            # normal case, the ':' starts the tag part
+            r, t = image.split(':', 2)
+          end
           repo r
           tag t if t
         end

--- a/spec/helpers_container_spec.rb
+++ b/spec/helpers_container_spec.rb
@@ -1,0 +1,82 @@
+require 'rspec'
+require 'rspec/its'
+require_relative '../libraries/helpers_container'
+
+class FakeContainerForTestingImageProperty
+  include DockerCookbook::DockerHelpers::Container
+
+  def initialize(attributes = {})
+    @attributes = attributes
+  end
+
+  def repo(value = nil)
+    attributes['repo'] = value if value
+    attributes['repo']
+  end
+
+  def tag(value = nil)
+    attributes['tag'] = value if value
+    attributes['tag'] || 'latest'
+  end
+
+  private
+
+  attr_reader :attributes
+end
+
+describe DockerCookbook::DockerHelpers::Container do
+  let(:helper) { FakeContainerForTestingImageProperty.new }
+
+  describe '#image' do
+    subject { helper }
+
+    context "If you say: repo 'blah'" do
+      before { helper.repo 'blah' }
+      its(:image) { is_expected.to eq('blah:latest') }
+    end
+
+    context "If you say: repo 'blah'; tag '3.1'" do
+      before do
+        helper.repo 'blah'
+        helper.tag '3.1'
+      end
+      its(:image) { is_expected.to eq('blah:3.1') }
+    end
+
+    context "If you say: image 'blah'" do
+      before { helper.image 'blah' }
+      its(:repo) { is_expected.to eq('blah') }
+      its(:tag) { is_expected.to eq('latest') }
+    end
+
+    context "If you say: image 'blah:3.1'" do
+      before { helper.image 'blah:3.1' }
+      its(:repo) { is_expected.to eq('blah') }
+      its(:tag) { is_expected.to eq('3.1') }
+    end
+
+    context "If you say: image 'repo/blah'" do
+      before { helper.image 'repo/blah' }
+      its(:repo) { is_expected.to eq('repo/blah') }
+      its(:tag) { is_expected.to eq('latest') }
+    end
+
+    context "If you say: image 'repo/blah:3.1'" do
+      before { helper.image 'repo/blah:3.1' }
+      its(:repo) { is_expected.to eq('repo/blah') }
+      its(:tag) { is_expected.to eq('3.1') }
+    end
+
+    context "If you say: image 'repo:1337/blah'" do
+      before { helper.image 'repo:1337/blah' }
+      its(:repo) { is_expected.to eq('repo:1337/blah') }
+      its(:tag) { is_expected.to eq('latest') }
+    end
+
+    context "If you say: image 'repo:1337/blah:3.1'" do
+      before { helper.image 'repo:1337/blah:3.1' }
+      its(:repo) { is_expected.to eq('repo:1337/blah') }
+      its(:tag) { is_expected.to eq('3.1') }
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes incorrect parsing of the `docker_container.image` property when the value looks like this: `repo:1337/blah:3.1`. It also adds full specs for the helper method that parses the value of `docker_container.image`.

The long story: when testing my wrapper cookbook, I found out that all my images were being redeployed at each chef-run with the following trace:

```
           * docker_container[my-test-app] action run
             - stopping my-test-app 
             - deleting my-test-app
             - update my-test-app
             -   set repo to "10.0.2.2:2000/sample-docker-app" (was "10.0.2.2")   # <<<-- bug
             -   set tag  to "latest" (was "2000/sample-docker-app:latest")  # <<<-- bug
             - starting my-test-app
```

The reason was that I used a private repository with a custom port and that it messed up the way the docker_container#image property is parsed.
