### PR TITLE
Note that -1 disables the swap limit, not swap itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ Most `docker_container` properties are the `snake_case` version of the
 - `mac_address` - The mac address for the container to use.
 - `memory` - Memory limit in bytes.
 - `memory_swap` - Total memory limit (memory + swap); set `-1` to
-  disable swap. You must use this with memory and make the swap value
+  disable swap limit (unlimited). You must use this with memory and make the swap value
   larger than memory.
 - `network_disabled` - Boolean to disable networking. Defaults to `false`.
 - `network_mode` - Sets the networking mode for the container. One of `bridge`,


### PR DESCRIPTION
Per https://github.com/docker/docker/issues/18894 and https://github.com/docker/docker/pull/18902 setting memory_swap to -1 does not disable swap, but instead disables the swap limit.  This change brings the README wording inline with the upstream wording changes in https://github.com/docker/docker/pull/18902.