### PR TITLE
Image load

### DIFF
--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -84,5 +84,11 @@ module DockerCookbook
         save_image
       end
     end
+
+    action :load do
+      converge_by "load image #{image_identifier}" do
+        load_image
+      end
+    end
   end
 end

--- a/libraries/helpers_image.rb
+++ b/libraries/helpers_image.rb
@@ -96,7 +96,7 @@ module DockerCookbook
 
       def load_image
         with_retries do
-          Docker::Image.load(source, (), connection)
+          Docker::Image.load(source, {}, connection)
         end
       end
     end

--- a/libraries/helpers_image.rb
+++ b/libraries/helpers_image.rb
@@ -93,6 +93,12 @@ module DockerCookbook
           Docker::Image.save(repo, destination, connection)
         end
       end
+
+      def load_image
+        with_retries do
+          Docker::Image.load(source, (), connection)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Implements load action for images
Requires [docker-api v1.27](https://github.com/swipely/docker-api/releases/tag/v1.27.0) 