### PR TITLE
include support for oracle platform for docker_service_manager_system…

### DIFF
--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -4,7 +4,7 @@ module DockerCookbook
 
     provides :docker_service_manager, platform: 'fedora'
 
-    provides :docker_service_manager, platform: %w(redhat centos scientific) do |node| # ~FC005
+    provides :docker_service_manager, platform: %w(redhat centos scientific oracle) do |node| # ~FC005
       node['platform_version'].to_f >= 7.0
     end
 

--- a/libraries/docker_service_manager_sysvinit_rhel.rb
+++ b/libraries/docker_service_manager_sysvinit_rhel.rb
@@ -4,13 +4,13 @@ module DockerCookbook
 
     provides :docker_service_manager, platform: 'amazon'
     provides :docker_service_manager, platform: 'suse'
-    provides :docker_service_manager, platform: %w(redhat centos scientific) do |node| # ~FC005
+    provides :docker_service_manager, platform: %w(redhat centos scientific oracle) do |node| # ~FC005
       node['platform_version'].to_f <= 7.0
     end
 
     provides :docker_service_manager_sysvinit, platform: 'amazon'
     provides :docker_service_manager_sysvinit, platform: 'suse'
-    provides :docker_service_manager_sysvinit, platform: %w(redhat centos scientific) do |node| # ~FC005
+    provides :docker_service_manager_sysvinit, platform: %w(redhat centos scientific oracle) do |node| # ~FC005
       node['platform_version'].to_f <= 7.0
     end
 


### PR DESCRIPTION
…d and docker_service_manager_sysvinit

Now that the oracle platform is supported, also ensure iniit/startup support as they are not currently installed on oracle platforms.