### PR TITLE
Minor README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,7 +1114,7 @@ Most `docker_container` properties are the `snake_case` version of the
 - `security_opts` - A list of string values to customize labels for
   MLS systems, such as SELinux.
 - `signal` - The signal to send when using the `:kill` action.
-  Defaults to `SIGKILL`.
+  Defaults to `SIGTERM`.
 - `tty` - Boolean value to allocate a pseudo-TTY. Defaults to `false`.
 - `user` - A string value specifying the user inside the container.
 - `volumes` - An Array of paths inside the container to expose. Does


### PR DESCRIPTION
### Description

Fix the documentation to update the default signal for `docker_container` to `SIGTERM`, which appears to be the resource default here:

https://github.com/chef-cookbooks/docker/blob/master/libraries/docker_container.rb#L76

### Issues Resolved

Resolves an inconsistency between the code and documentation.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

