### PR TITLE
Add http_proxy support for rhel/sysvinit systems

### DIFF
--- a/templates/default/sysconfig/docker.erb
+++ b/templates/default/sysconfig/docker.erb
@@ -5,3 +5,15 @@
 # to the arguments list passed to docker
 
 other_args="<%= @docker_daemon_opts %>"
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+<% if @config.http_proxy %>
+export http_proxy="<%= @config.http_proxy %>"
+<% end %>
+<% if @config.https_proxy %>
+export https_proxy="<%= @config.https_proxy %>"
+<% end %>
+
+<% if @config.no_proxy %>
+export no_proxy="<%= @config.no_proxy %>"
+<% end %>


### PR DESCRIPTION
Support `http_proxy`, `https_proxy` and `no_proxy` variables in RHEL sysconfig the same way than Debian's `/etc/default/docker`.