### PR TITLE
Avoid installing docker-api gem in ChefSpec

### DIFF
--- a/libraries/_autoload.rb
+++ b/libraries/_autoload.rb
@@ -1,11 +1,13 @@
 begin
   gem 'docker-api', '= 1.28.0'
 rescue LoadError
-  run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
+  unless defined?(ChefSpec)
+    run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
 
-  require 'chef/resource/chef_gem'
+    require 'chef/resource/chef_gem'
 
-  docker = Chef::Resource::ChefGem.new('docker-api', run_context)
-  docker.version '= 1.28.0'
-  docker.run_action(:install)
+    docker = Chef::Resource::ChefGem.new('docker-api', run_context)
+    docker.version '= 1.28.0'
+    docker.run_action(:install)
+  end
 end


### PR DESCRIPTION
### Description

Avoid forcing cookbooks directly or indirectly depends on "docker" cookbook to install docker-api gem when they run chefspec.

### Issues Resolved

Currently docker cookbook forces every single cookbook which directly or
indirectly depends on docker cookbook to install docker-api when they run
their chefspec or to stub-out installation of the gem.
It should have been unnecessary unless those chefspecs step into recipes
defined in docker cookbook.

This commit avoid installing docker-api when this cookbook is loaded as
a part of chefspec.

Without this change, chefspec in dependent cookbooks would have errors
like this.

```console
     Failure/Error: runner.converge(described_recipe)

     NoMethodError:
       undefined method `step_into?' for nil:NilClass
     # /Users/yugui/.chefdk/gem/ruby/2.1.0/gems/chefspec-4.6.1/lib/chefspec/extensions/chef/resource.rb:20:in `run_action'
     # /var/folders/0w/zk0cjpln04jdxrccy7vpp9pw0000gn/T/d20160511-21028-fn0j7k/cookbooks/docker/libraries/_autoload.rb:10:in `rescue in <top (required)>'
     # /var/folders/0w/zk0cjpln04jdxrccy7vpp9pw0000gn/T/d20160511-21028-fn0j7k/cookbooks/docker/libraries/_autoload.rb:1:in `<top (required)>'
     # /Users/yugui/.chefdk/gem/ruby/2.1.0/gems/chefspec-4.6.1/lib/chefspec/solo_runner.rb:117:in `converge'
     # ./spec/runner.rb:11:in `block (2 levels) in <top (required)>'
     # ./spec/default_spec.rb:24:in `block (4 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Gem::LoadError:
     #   docker-api is not part of the bundle. Add it to Gemfile.
     #   /var/folders/0w/zk0cjpln04jdxrccy7vpp9pw0000gn/T/d20160511-21028-fn0j7k/cookbooks/docker/libraries/_autoload.rb:2:in `<top (required)>'
```

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

