### PR TITLE
Fedora 22/23 support

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -26,7 +26,7 @@ platforms:
   transport:
     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
   run_list:
-  - recipe[yum-docker]
+  - recipe[chef-yum-docker]
 
 - name: centos-7.0
   driver_plugin: digitalocean
@@ -38,7 +38,7 @@ platforms:
   transport:
     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
   run_list:
-  - recipe[yum-docker]
+  - recipe[chef-yum-docker]
 
 # - name: amazon-2014.09
 #   driver_plugin: ec2
@@ -48,7 +48,7 @@ platforms:
 #   transport:
 #     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
 #  run_list:
-#  - recipe[yum-docker]
+#  - recipe[chef-yum-docker]
 
 - name: fedora-21
   driver_plugin: digitalocean
@@ -60,7 +60,7 @@ platforms:
   transport:
     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
   run_list:
-  - recipe[yum-docker]
+  - recipe[chef-yum-docker]
 
 # - name: debian-8.1
 #   driver_plugin: digitalocean

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,15 +19,16 @@ verifier:
 platforms:
 - name: centos-6.7
   run_list:
-  - recipe[yum-docker]
+  - recipe[chef-yum-docker]
 
 - name: centos-7.2
   run_list:
-  - recipe[yum-docker]
+  - recipe[chef-yum-docker]
 
-- name: fedora-22
+- name: fedora-23
   run_list:
-  - recipe[yum-docker]
+  - recipe[yum::dnf_yum_compat]
+  - recipe[chef-yum-docker]
 
 - name: debian-7.10
   run_list:
@@ -129,7 +130,8 @@ suites:
     'centos-7.2',
     'debian-8.4',
     'ubuntu-12.04',
-    'ubuntu-14.04'
+    'ubuntu-14.04',
+    'fedora-23'
    ]
   attributes:
     docker:
@@ -143,7 +145,8 @@ suites:
     'debian-8.4',
     'ubuntu-12.04',
     'ubuntu-14.04',
-    'ubuntu-16.04'
+    'ubuntu-16.04',
+    'fedora-23'
    ]
   attributes:
     docker:

--- a/Berksfile
+++ b/Berksfile
@@ -4,8 +4,9 @@ metadata
 
 group :integration do
   cookbook 'apt'
+  cookbook 'yum'
   cookbook 'chef-apt-docker'
-  cookbook 'yum-docker'
+  cookbook 'chef-yum-docker'
   cookbook 'etcd'
   cookbook 'docker_test', path: 'test/cookbooks/docker_test'
 end

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ end
 
 ## docker_installation_package
 
-The `docker_installation_package` resource uses the system package manager to install Docker. It relies on the pre-configuration of the system's package repositories. The excellent `yum-docker` and `apt-docker` Supermarket cookbooks are used to do this in test-kitchen.
+The `docker_installation_package` resource uses the system package manager to install Docker. It relies on the pre-configuration of the system's package repositories. The `chef-yum-docker` and `chef-apt-docker` Supermarket cookbooks are used to do this in test-kitchen.
 
 This is the recommended production installation method.
 

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -288,7 +288,7 @@ module DockerCookbook
       converge_by "starting #{container_name}" do
         with_retries do
           container.start
-          timeout ? container.wait(timeout) : container.wait unless detach
+          timeout ? container.wait(timeout) : container.wait unless detach # rubocop: disable Style/IfUnlessModifierOfIfUnless
         end
         wait_running_state(true) if detach
       end

--- a/libraries/helpers_base.rb
+++ b/libraries/helpers_base.rb
@@ -31,8 +31,8 @@ module DockerCookbook
       def coerce_shell_command(v)
         return nil if v.nil?
         return DockerBase::ShellCommandString.new(
-          ::Shellwords.join(v)) if v.is_a?(Array
-                                          )
+          ::Shellwords.join(v)
+        ) if v.is_a?(Array)
         DockerBase::ShellCommandString.new(v)
       end
 

--- a/libraries/helpers_installation_package.rb
+++ b/libraries/helpers_installation_package.rb
@@ -11,8 +11,8 @@ module DockerCookbook
         false
       end
 
-      def fc21?
-        return true if node['platform'] == 'fedora' && node['platform_version'] == '21'
+      def fedora?
+        return true if node['platform'] == 'fedora'
         false
       end
 
@@ -61,7 +61,7 @@ module DockerCookbook
         return "#{v}-1.el6" if el6?
         return "#{v}-1.el7.centos" if el7?
         return "#{v}-1.el6" if amazon?
-        return "#{v}-1.fc21" if fc21?
+        return "#{v}-1.fc#{node['platform_version'].to_i}" if fedora?
         return "#{v}-0~wheezy" if wheezy?
         return "#{v}-0~jessie" if jesse?
         return "#{v}-0~precise" if precise?
@@ -75,7 +75,6 @@ module DockerCookbook
       def default_docker_version
         return '1.7.1' if el6?
         return '1.7.1' if amazon?
-        return '1.9.1' if fc21?
         return '1.9.1' if vivid?
         '1.11.1'
       end


### PR DESCRIPTION
### Description

Remove the Fedora 21 specific support and instead use generic Fedora support. Also use the latest version on Fedora since 1.9 doesn't even exist there.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

