### PR TITLE
Install Docker 1.11.0+ using tarballs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -60,6 +60,20 @@ platforms:
 
 suites:
 #####################################
+# docker_installation_tarball resource
+#####################################
+
+- name: installation_tarball-1111
+  includes: [
+    'ubuntu-16.04'
+   ]
+  attributes:
+    docker:
+      version: '1.11.1'
+  run_list:
+  - recipe[docker_test::installation_tarball]
+
+#####################################
 # docker_installation_binary resource
 #####################################
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,27 @@ end
 - `source` - Path to network accessible Docker binary. Ignores version
 - `checksum` - SHA-256
 
+## docker_installation_tarball
+
+The `docker_installation_tarball` resource copies the precompiled Go binary tarball onto the disk. It exists to help run newer Docker versions from 1.11.0 onwards. It should not be used in production, especially with devicemapper.
+
+### Example
+
+```ruby
+docker_installation_tarball 'default' do
+  version '1.11.0'
+  source 'https://my.computers.biz/dist/docker.tgz'
+  checksum '97a3f5924b0b831a310efa8bf0a4c91956cd6387c4a8667d27e2b2dd3da67e4d'
+  action :create
+end
+```
+
+### Properties
+
+- `version` - The desired version of docker. Used to calculate source.
+- `source` - Path to network accessible Docker binary tarball. Ignores version
+- `checksum` - SHA-256
+
 ## docker_installation_script
 
 The `docker_installation_script` resource runs the script hosted by Docker, Inc at <http://get.docker.com>. It configures package repositories and installs a dynamically compiled binary.

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -1,0 +1,47 @@
+module DockerCookbook
+  class DockerInstallationTarball < DockerBase
+    require_relative 'helpers_installation_tarball'
+
+    include DockerHelpers::InstallationTarball
+
+    #####################
+    # Resource properties
+    #####################
+    resource_name :docker_installation_tarball
+
+    property :checksum, String, default: lazy { default_checksum }, desired_state: false
+    property :source, String, default: lazy { default_source }, desired_state: false
+    property :version, String, default: lazy { default_version }, desired_state: false
+
+    default_action :create
+
+    #########
+    # Actions
+    #########
+
+    action :create do
+      # Pull a precompiled binary off the network
+      remote_file docker_tarball do
+        source new_resource.source
+        checksum new_resource.checksum
+        owner 'root'
+        group 'root'
+        mode '0755'
+        action :create
+        notifies :run, 'execute[extract tarball]', :immediately
+      end
+
+      execute 'extract tarball' do
+        action :nothing
+        command "tar -xzf #{docker_tarball} --strip-components=1 -C #{docker_bin_prefix}"
+        creates docker_bin
+      end
+    end
+
+    action :delete do
+      file docker_bin do
+        action :delete
+      end
+    end
+  end
+end

--- a/libraries/helpers_installation_tarball.rb
+++ b/libraries/helpers_installation_tarball.rb
@@ -1,0 +1,48 @@
+module DockerCookbook
+  module DockerHelpers
+    module InstallationTarball
+      def docker_bin_prefix
+        '/usr/bin'
+      end
+
+      def docker_bin
+        "#{docker_bin_prefix}/docker"
+      end
+
+      def docker_tarball
+        "#{Chef::Config[:file_cache_path]}/docker-#{version}.tgz"
+      end
+
+      def docker_kernel
+        node['kernel']['name']
+      end
+
+      def docker_arch
+        node['kernel']['machine']
+      end
+
+      def default_source
+        "https://get.docker.com/builds/#{docker_kernel}/#{docker_arch}/docker-#{version}.tgz"
+      end
+
+      def default_checksum
+        case docker_kernel
+        when 'Darwin'
+          case version
+          when '1.11.0' then '25e4f5f37e2e17beb20e5a468674750350824059bdeeca09d6a941bca8fc4f73'
+          when '1.11.1' then '6d35487fbcc7e3f722f3d5f3e5c070a41d87c88e3770f52ae28460a689c40efd'
+          end
+        when 'Linux'
+          case version
+          when '1.11.0' then '87331b3b75d32d3de5d507db9a19a24dd30ff9b2eb6a5a9bdfaba954da15e16b'
+          when '1.11.1' then '893e3c6e89c0cd2c5f1e51ea41bc2dd97f5e791fcfa3cee28445df277836339d'
+          end
+        end
+      end
+
+      def default_version
+        '1.11.1'
+      end
+    end
+  end
+end

--- a/test/cookbooks/docker_test/recipes/installation_tarball.rb
+++ b/test/cookbooks/docker_test/recipes/installation_tarball.rb
@@ -1,0 +1,4 @@
+docker_installation_tarball 'default' do
+  version node['docker']['version']
+  action :create
+end

--- a/test/integration/installation_tarball-1111/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_tarball-1111/inspec/assert_functioning_spec.rb
@@ -1,0 +1,5 @@
+
+describe command('/usr/bin/docker --version') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/1.11.1/) }
+end


### PR DESCRIPTION
### Description

The binary installation method in Docker 1.10.0 onwards changed [1].
The old one is still compatible up to 1.10.+ but doesn't work with
1.11.0 onwards.

This new resource accomodates this method. I think adding a new resource
is better rather than complicating the logic in the existingh
docker_installation_binary resource.

[1] https://docs.docker.com/engine/installation/binaries/#install-the-linux-binaries

### Issues Resolved

None

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


