### PR TITLE
DOCKER-714 added ability to configure namespace for daemon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ The `docker_service` resource property list mostly corresponds to the options fo
 - `logfile` - Location of Docker daemon log file
 - `userland_proxy`- Enables or disables docker-proxy
 - `disable_legacy_registry` - Do not contact legacy registries
+- `userns_remap` - Configure namespace remapping
 
 ### Actions
 

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -58,7 +58,7 @@ module DockerCookbook
     property :default_ulimit, ArrayType
     property :userland_proxy, [Boolean, nil]
     property :disable_legacy_registry, [Boolean, nil]
-    property :userns_remap , [String, nil]
+    property :userns_remap, [String, nil]
 
     # environment variables to set before running daemon
     property :http_proxy, [String, nil]

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -58,6 +58,7 @@ module DockerCookbook
     property :default_ulimit, ArrayType
     property :userland_proxy, [Boolean, nil]
     property :disable_legacy_registry, [Boolean, nil]
+    property :userns_remap , [String, nil]
 
     # environment variables to set before running daemon
     property :http_proxy, [String, nil]

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -191,6 +191,7 @@ module DockerCookbook
         opts << "--tlskey=#{tls_server_key}" if tls_server_key
         opts << "--userland-proxy=#{userland_proxy}" unless userland_proxy.nil?
         opts << "--disable-legacy-registry=#{disable_legacy_registry}" unless disable_legacy_registry.nil?
+        opts << "--userns-remap=#{userns-remap}" if userns-remap
         opts
       end
 

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -191,7 +191,7 @@ module DockerCookbook
         opts << "--tlskey=#{tls_server_key}" if tls_server_key
         opts << "--userland-proxy=#{userland_proxy}" unless userland_proxy.nil?
         opts << "--disable-legacy-registry=#{disable_legacy_registry}" unless disable_legacy_registry.nil?
-        opts << "--userns-remap=#{userns-remap}" if userns-remap
+        opts << "--userns-remap=#{userns_remap}" if userns_remap
         opts
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Cookbook Engineering Team'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Provides docker_service, docker_image, and docker_container resources'
-version '2.7.1'
+version '2.8.0'
 
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'


### PR DESCRIPTION
### Description

Adds the ability to configure the --userns-remap= daemon namepace option by setting the userns_remap parameter to the docker_service resource 

### Issues Resolved

Fixes issue 714 submitted by myself.

### Check List
- [x ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x ] New functionality includes testing.
- [x ] New functionality has been documented in the README if applicable
- [x ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

