### PR TITLE
Switch to the dockerd binary on 1.12+

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -31,6 +31,10 @@ module DockerCookbook
         '/usr/bin/docker'
       end
 
+      def dockerd_bin
+        '/usr/bin/dockerd'
+      end
+
       def docker_name
         return 'docker' if name == 'default'
         "docker-#{name}"
@@ -122,13 +126,20 @@ module DockerCookbook
       def docker_daemon_arg
         if Gem::Version.new(docker_major_version) < Gem::Version.new('1.8')
           '-d'
-        else
+        elsif Gem::Version.new(docker_major_version) < Gem::Version.new('1.12')
           'daemon'
+        else
+          ''
         end
       end
 
       def docker_daemon_cmd
-        [docker_bin, docker_daemon_arg, docker_daemon_opts].join(' ')
+        bin = if Gem::Version.new(docker_major_version) < Gem::Version.new('1.12')
+                docker_bin
+              else
+                dockerd_bin
+              end
+        [bin, docker_daemon_arg, docker_daemon_opts].join(' ')
       end
 
       def docker_cmd


### PR DESCRIPTION
### Description

Add logic to use the dockerd binary on docker 1.12+. Init scripts still need to be updated as some `/usr/bin/docker` invocations are hardwired.

### Issues Resolved

None

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


