### PR TITLE
Add extra options to daemon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# is needed until Chef DK has Ruby version >= 2.2.2
+gem 'activesupport', '=4.2.6'
+
 group :docker do
   gem 'docker-api', '= 1.28.0'
 end

--- a/README.md
+++ b/README.md
@@ -446,6 +446,9 @@ The `docker_service` resource property list mostly corresponds to the options fo
 - `disable_legacy_registry` - Do not contact legacy registries
 - `userns_remap` - Enable user namespace remapping options - `default`, `uid`, `uid:gid`, `username`, `username:groupname` (see: [Docker User Namespaces](see: https://docs.docker.com/v1.10/engine/reference/commandline/daemon/#daemon-user-namespace-options))
 
+##### Miscellaneous Options
+- `misc_opts` - Pass the docker daemon any other options bypassing flag validation, supplied as `--flag=value`
+
 ### Actions
 
 - `:create` - Lays the Docker bits out on disk

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -60,6 +60,9 @@ module DockerCookbook
     property :disable_legacy_registry, [Boolean, nil]
     property :userns_remap, [String, nil]
 
+    # These are unvalidated daemon arguments passed in as a string.
+    property :misc_opts, [String, nil]
+
     # environment variables to set before running daemon
     property :http_proxy, [String, nil]
     property :https_proxy, [String, nil]

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -192,6 +192,7 @@ module DockerCookbook
         opts << "--userland-proxy=#{userland_proxy}" unless userland_proxy.nil?
         opts << "--disable-legacy-registry=#{disable_legacy_registry}" unless disable_legacy_registry.nil?
         opts << "--userns-remap=#{userns_remap}" if userns_remap
+        opts << misc_opts if misc_opts
         opts
       end
 


### PR DESCRIPTION
### Description

I am using this cookbook with flannel. Flannel creates a docker bridge, and exposes the docker bip subnet through an env file. I can override the systemd environmentFile option through using the docker-instance.d/ conf file easily.

However, to pass the environment variable in the env file to the docker daemon, i need to evaluate the var at runtime, by setting something like this ```--bip=${FLANNEL_SUBNET}``` at docker daemon runtime.

Therefore I need to set the bip property of the docker_service provider to ```${FLANNEL_SUBNET}```, however it fails IP address validation against the regex in the provider, understandably.

Therefore, we should be able to pass arguments as strings to avoid validation in these edgecases.

### Issues Resolved
None.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


