### PR TITLE
Add uts_mode support for docker_container provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :kitchen_common do
   gem 'test-kitchen', '~> 1.5.0'
   gem 'kitchen-sync'
   gem 'kitchen-inspec'
+  gem 'activesupport', '< 5.0.0'
 end
 
 group :kitchen_vagrant do

--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,9 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `tls_client_cert` - Path to TLS certificate file for docker cli. Defaults to ENV['DOCKER_CERT_PATH'] if set
 - `tls_client_key` - Path to TLS key file for docker cli. Defaults to ENV['DOCKER_CERT_PATH'] if set
 - `userns_mode` - Modify the user namespace mode - Defaults to `nil`, example option: `host`
+- `pid_mode` - Set the PID (Process) Namespace mode for the container. `host`: use the host's PID namespace inside the container. 
+- `ipc_mode` - Set the IPC mode for the container - Defaults to `nil`, example option: `host`
+- `uts_mode` - Set the UTS namespace mode for the container. The UTS namespace is for setting the hostname and the domain that is visible to running processes in that namespace. By default, all containers, including those with `--network=host`, have their own UTS namespace. The host setting will result in the container using the same UTS namespace as the host. Note that --hostname is invalid in host UTS mode.
 - `ro_rootfs` - Mount the container's root filesystem as read only. Defaults to `false`
 
 ### Actions

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -81,6 +81,7 @@ module DockerCookbook
     property :ulimits, [Array, nil], coerce: proc { |v| coerce_ulimits(v) }
     property :user, String, default: ''
     property :userns_mode, String, default: ''
+    property :uts_mode, String, default: ''
     property :volumes, PartialHashType, default: {}, coerce: proc { |v| coerce_volumes(v) }
     property :volumes_from, ArrayType
     property :working_dir, [String, NilClass], default: ''
@@ -278,6 +279,7 @@ module DockerCookbook
               'ReadonlyRootfs'  => ro_rootfs,
               'Ulimits'         => ulimits_to_hash,
               'UsernsMode'      => userns_mode,
+              'UTSMode'         => uts_mode,
               'VolumesFrom'     => volumes_from
             }
           }

--- a/spec/docker_test/container_spec.rb
+++ b/spec/docker_test/container_spec.rb
@@ -857,6 +857,12 @@ describe 'docker_test::container' do
         ipc_mode: 'host'
       )
     end
+
+    it 'run_if_missing docker_container[uts_mode]' do
+      expect(chef_run).to run_if_missing_docker_container('uts_mode').with(
+        uts_mode: 'host'
+      )
+    end
   end
 
   context 'testing ro_rootfs' do

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -987,6 +987,18 @@ docker_container 'ipc_mode' do
   action :run_if_missing
 end
 
+##########
+# uts_mode
+##########
+
+docker_container 'uts_mode' do
+  repo 'alpine'
+  tag '3.1'
+  command 'ps -ef'
+  uts_mode 'host'
+  action :run_if_missing
+end
+
 ##################
 # read-only rootfs
 ##################

--- a/test/integration/resources-1100/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources-1100/inspec/assert_functioning_spec.rb
@@ -878,6 +878,18 @@ describe command("docker inspect --format '{{ .HostConfig.IpcMode }}' ipc_mode")
   its(:stdout) { eq 'host' }
 end
 
+# docker_container[uts_mode]
+
+describe command("docker ps -af 'name=uts_mode$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.UTSMode }}' uts_mode") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { eq 'host' }
+end
+
 # containers shouldnt be killed, validating only one was force killed
 
 describe command("docker ps -qaf 'exited=137' | wc -l") do

--- a/test/integration/resources-1112/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources-1112/inspec/assert_functioning_spec.rb
@@ -878,6 +878,18 @@ describe command("docker inspect --format '{{ .HostConfig.IpcMode }}' ipc_mode")
   its(:stdout) { eq 'host' }
 end
 
+# docker_container[uts_mode]
+
+describe command("docker ps -af 'name=uts_mode$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.UTSMode }}' uts_mode") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { eq 'host' }
+end
+
 # containers shouldnt be killed, validating only one was force killed
 
 describe command("docker ps -qaf 'exited=137' | wc -l") do

--- a/test/integration/resources-162/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/inspec/assert_functioning_spec.rb
@@ -878,6 +878,18 @@ describe command("docker inspect --format '{{ .HostConfig.IpcMode }}' ipc_mode")
   its(:stdout) { eq 'host' }
 end
 
+# docker_container[uts_mode]
+
+describe command("docker ps -af 'name=uts_mode$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.UTSMode }}' uts_mode") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { eq 'host' }
+end
+
 # containers shouldnt be killed, validating only one was force killed
 
 describe command("docker ps -qaf 'exited=137' | wc -l") do

--- a/test/integration/resources-171/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/inspec/assert_functioning_spec.rb
@@ -878,6 +878,18 @@ describe command("docker inspect --format '{{ .HostConfig.IpcMode }}' ipc_mode")
   its(:stdout) { eq 'host' }
 end
 
+# docker_container[uts_mode]
+
+describe command("docker ps -af 'name=uts_mode$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.UTSMode }}' uts_mode") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { eq 'host' }
+end
+
 # containers shouldnt be killed, validating only one was force killed
 
 describe command("docker ps -qaf 'exited=137' | wc -l") do

--- a/test/integration/resources-183/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources-183/inspec/assert_functioning_spec.rb
@@ -878,6 +878,18 @@ describe command("docker inspect --format '{{ .HostConfig.IpcMode }}' ipc_mode")
   its(:stdout) { eq 'host' }
 end
 
+# docker_container[uts_mode]
+
+describe command("docker ps -af 'name=uts_mode$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.UTSMode }}' uts_mode") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { eq 'host' }
+end
+
 # containers shouldnt be killed, validating only one was force killed
 
 describe command("docker ps -qaf 'exited=137' | wc -l") do

--- a/test/integration/resources-191/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources-191/inspec/assert_functioning_spec.rb
@@ -878,6 +878,18 @@ describe command("docker inspect --format '{{ .HostConfig.IpcMode }}' ipc_mode")
   its(:stdout) { eq 'host' }
 end
 
+# docker_container[uts_mode]
+
+describe command("docker ps -af 'name=uts_mode$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.UTSMode }}' uts_mode") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { eq 'host' }
+end
+
 # containers shouldnt be killed, validating only one was force killed
 
 describe command("docker ps -qaf 'exited=137' | wc -l") do


### PR DESCRIPTION
### Description

Add uts_mode support for docker_container provider. 

https://docs.docker.com/engine/reference/run/#/uts-settings-uts here is option description.

> UTS settings (--uts)
> --uts=""  : Set the UTS namespace mode for the container,
>        'host': use the host's UTS namespace inside the container
> The UTS namespace is for setting the hostname and the domain that is visible to running processes in that namespace. By default, all containers, including those with --network=host, have their own UTS namespace. The host setting will result in the container using the same UTS namespace as the host. Note that --hostname is invalid in host UTS mode.
>You may wish to share the UTS namespace with the host if you would like the hostname of the container to change as the hostname of the host changes. A more advanced use case would be changing the host’s hostname from a container.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

