### PR TITLE
Fix pull from private dockerhub repository

### DIFF
--- a/libraries/helpers_image.rb
+++ b/libraries/helpers_image.rb
@@ -65,7 +65,7 @@ module DockerCookbook
       def pull_image
         with_retries do
           registry_host = parse_registry_host(repo)
-          creds = node.run_state['docker_auth'] && node.run_state['docker_auth'][registry_host] || (node.run_state['docker_auth'] ||= {})['index.docker.io']
+          creds = node.run_state['docker_auth'] && node.run_state['docker_auth'][registry_host] || (node.run_state['docker_auth'] ||= {})['index.docker.io'].tap { |hs| hs.delete("serveraddress") }
 
           original_image = Docker::Image.get(image_identifier, {}, connection) if Docker::Image.exist?(image_identifier, {}, connection)
           new_image = Docker::Image.create({ 'fromImage' => image_identifier }, creds, connection)


### PR DESCRIPTION
### Description

When try to pull a container from private dockerhub we are receiving the follow message:

`Docker::Error::NotFoundError
    ----------------------------
    No such image: arizona/carrefour-web-view-nginx:develop`

The bug:
The method are receiving credentials create a header with creds data to call dockerhub api. This headers is a composition of username, password and email, but the cookbook is passing serverAddress and the header goes broken.

Non-Ok creds:
`creds = {"serveraddress"=>"index.docker.io", "username"=>"XXX", "password"=>"XXX", "email"=>"XXX"}
`
Ok creds:
`creds = {"username"=>"XXX", "password"=>"XXX", "email"=>"XXX"}
`
### Issues Resolved

No issues reported
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
