### PR TITLE
Don't send command propery to docker API unless explicitly specified …

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -234,7 +234,7 @@ module DockerCookbook
             'name'            => container_name,
             'Image'           => "#{repo}:#{tag}",
             'Labels'          => labels,
-            'Cmd'             => to_shellwords(command),
+            'Cmd'             => property_is_set?(:command) ? to_shellwords(command) : nil,
             'AttachStderr'    => attach_stderr,
             'AttachStdin'     => attach_stdin,
             'AttachStdout'    => attach_stdout,


### PR DESCRIPTION
### Description

When a dockerfile has a command at the end, if that command in the dockerfile is modified chef will not respect that change.

Full description from my coworker who made the change:

> The container resource uses a common pattern of loading the current running values on the server, so that it can compare them to the values specified in our resource definition to see if anything has changed and know if it needs to restart the container with new values (https://github.com/chef-cookbooks/docker/blob/master/libraries/docker_container.rb#L122). The docker API call returns all properties of a running container, regardless of whether they were specified in the previous chef client run. The problem is that one of those properties is the "Command", which we actually don't specify currently in our resource definition, relying on the "CMD" property in the dockerfile to take care of that for us.
> 
> So, in our scenario, when the container resource runs, it grabs the Command property from the running container (which is the Command from the previous version of the dockerfile). It detects that something has changed in the resource (the "tag" property), so it knows it needs to stop, delete, and re-run the container. Since we don't specify the Command property in our resource definition, it passes the currently running value of Command into the docker API, along with all the other properties (https://github.com/chef-cookbooks/docker/blob/master/libraries/docker_container.rb#L237). So we end up with a container that looks like it's been upgraded, but is actually running the command from the previous version of the dockerfile.
### Issues Resolved
#673
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

…in resource
