### PR TITLE
Dockerd binary on 1.12+ for Upstart

### DIFF
--- a/libraries/docker_service_manager_upstart.rb
+++ b/libraries/docker_service_manager_upstart.rb
@@ -26,6 +26,7 @@ module DockerCookbook
         source 'default/docker.erb'
         variables(
           config: new_resource,
+          docker_daemon: docker_daemon,
           docker_daemon_opts: docker_daemon_opts.join(' ')
         )
         cookbook 'docker'

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -123,6 +123,14 @@ module DockerCookbook
         ray.push.join('.')
       end
 
+      def docker_daemon
+        if Gem::Version.new(docker_major_version) < Gem::Version.new('1.12')
+          docker_bin
+        else
+          dockerd_bin
+        end
+      end
+
       def docker_daemon_arg
         if Gem::Version.new(docker_major_version) < Gem::Version.new('1.8')
           '-d'
@@ -134,12 +142,7 @@ module DockerCookbook
       end
 
       def docker_daemon_cmd
-        bin = if Gem::Version.new(docker_major_version) < Gem::Version.new('1.12')
-                docker_bin
-              else
-                dockerd_bin
-              end
-        [bin, docker_daemon_arg, docker_daemon_opts].join(' ')
+        [docker_daemon, docker_daemon_arg, docker_daemon_opts].join(' ')
       end
 
       def docker_cmd

--- a/templates/default/default/docker.erb
+++ b/templates/default/default/docker.erb
@@ -1,7 +1,7 @@
 # Docker Upstart and SysVinit configuration file
 
 # Customize location of Docker binary (especially for development testing).
-DOCKER="<%= @config.docker_bin %>"
+DOCKER="<%= @docker_daemon %>"
 
 # Use DOCKER_OPTS to modify the daemon startup options.
 DOCKER_OPTS="<%= @docker_daemon_opts %>"


### PR DESCRIPTION
### Description

Starting from Docker 1.12 /usr/bin/dockerd should be used instead of /usr/bin/docker in Upstart init script.

### Issues Resolved

Fix for issue with starting Docker 1.12+ using Upstart.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


