### PR TITLE
Fixed dns options mutual exclusion

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -194,12 +194,9 @@ module DockerCookbook
       if network_mode == 'host' &&
          (
           !(hostname.nil? || hostname.empty?) ||
-          !(dns.nil? || dns.empty?) ||
-          !(dns_search.nil? || dns_search.empty?) ||
-          !(mac_address.nil? || mac_address.empty?) ||
-          !(extra_hosts.nil? || extra_hosts.empty?)
+          !(mac_address.nil? || mac_address.empty?)
          )
-        raise Chef::Exceptions::ValidationFailed, 'Cannot specify hostname, dns, dns_search, mac_address, or extra_hosts when network_mode is host.'
+        raise Chef::Exceptions::ValidationFailed, 'Cannot specify hostname or mac_address when network_mode is host.'
       end
 
       if network_mode == 'container' &&


### PR DESCRIPTION
Docker versions starting from v1.12 support setting of dns options and they are not mutually exclusive with **host network_mode**.
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
