### PR TITLE
Fix regression introduced by #741, breaking Debian install

### DIFF
--- a/libraries/docker_service_manager_sysvinit_debian.rb
+++ b/libraries/docker_service_manager_sysvinit_debian.rb
@@ -67,6 +67,7 @@ module DockerCookbook
           source 'default/docker.erb'
           variables(
             config: new_resource,
+            docker_daemon: docker_daemon,
             docker_daemon_opts: docker_daemon_opts.join(' ')
           )
           cookbook 'docker'


### PR DESCRIPTION
### Description

`docker_daemon` variable has been added to `templates/default/default/docker.erb` in #741, which is used by `docker_service_manager_sysvinit_debian` and `docker_service_manager_upstart` resources.
Only Upstart resource has been updated in said PR, breaking sysvinit Debian setups.
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Signed-off-by: Jonathan Amiez jonathan.amiez@gmail.com
