### PR TITLE
Allow customizing systemd MountFlags option

### DIFF
--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -16,6 +16,8 @@ module DockerCookbook
       node['platform_version'].to_f >= 15.04
     end
 
+    property :systemd_mountflags, String, default: 'private'
+
     action :start do
       create_docker_wait_ready
 

--- a/templates/default/systemd/docker.service-override.erb
+++ b/templates/default/systemd/docker.service-override.erb
@@ -26,7 +26,7 @@ ExecStartPre=/sbin/sysctl -w net.ipv6.conf.all.forwarding=1
 ExecStart=<%= @docker_daemon_cmd %>
 ExecStartPost=<%= @docker_wait_ready %>
 Restart=always
-MountFlags=private
+MountFlags=<%= @config.systemd_mountflags %>
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity


### PR DESCRIPTION
### Description

This change allows customizing the Systemd MountFlags option when Docker is launched by systemd.
### Issues Resolved

Prior to that change, the Systemd MountFlags option was hardcoded to 'private' in the template file.
