### PR TITLE
Enable tarball install through docker_service

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -201,6 +201,24 @@ suites:
   - recipe[docker_test::installation_package]
 
 #################################
+# docker_service_install resource
+#################################
+- name: service_install_tarball-1111
+  includes: [
+    'centos-7.2',
+    'debian-7.11',
+    'debian-8.5',
+    'ubuntu-14.04',
+    'ubuntu-16.04',
+    'fedora-24'
+   ]
+  attributes:
+    docker:
+      version: '1.11.1'
+  run_list:
+  - recipe[docker_test::service_install_tarball]
+
+#################################
 # docker_service_execute resource
 #################################
 - name: service-execute

--- a/libraries/docker_service.rb
+++ b/libraries/docker_service.rb
@@ -8,14 +8,14 @@ module DockerCookbook
     provides :docker_service
 
     # installation type and service_manager
-    property :install_method, %w(binary script package none auto), default: 'auto', desired_state: false
+    property :install_method, %w(binary script package tarball none auto), default: 'auto', desired_state: false
     property :service_manager, %w(execute sysvinit upstart systemd auto), default: 'auto', desired_state: false
 
     # docker_installation_script
     property :repo, desired_state: false
     property :script_url, String, desired_state: false
 
-    # docker_installation_binary
+    # docker_installation_binary and tarball
     property :checksum, String, desired_state: false
     property :docker_bin, String, desired_state: false
     property :source, String, desired_state: false
@@ -23,7 +23,7 @@ module DockerCookbook
     # docker_installation_package
     property :package_version, String, desired_state: false
 
-    # binary and package
+    # binary, package and tarball
     property :version, String, desired_state: false
     property :package_options, [String, nil], desired_state: false
 
@@ -33,8 +33,9 @@ module DockerCookbook
     def validate_install_method
       if property_is_set?(:version) &&
          install_method != 'binary' &&
-         install_method != 'package'
-        raise Chef::Exceptions::ValidationFailed, 'Version property only supported for binary and package installation methods'
+         install_method != 'package' &&
+         install_method != 'tarball'
+        raise Chef::Exceptions::ValidationFailed, 'Version property only supported for binary, package and tarball installation methods'
       end
     end
 
@@ -60,6 +61,8 @@ module DockerCookbook
           install = docker_installation_script(name, &block)
         when 'package'
           install = docker_installation_package(name, &block)
+        when 'tarball'
+          install = docker_installation_tarball(name, &block)
         when 'none'
           Chef::Log.info('Skipping Docker installation. Assuming it was handled previously.')
           return

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Cookbook Engineering Team'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Provides docker_service, docker_image, and docker_container resources'
-version '2.9.7'
+version '2.9.8'
 
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'

--- a/test/cookbooks/docker_test/recipes/service_install_tarball.rb
+++ b/test/cookbooks/docker_test/recipes/service_install_tarball.rb
@@ -1,0 +1,10 @@
+
+################
+# Docker service
+################
+
+docker_service 'default' do
+  install_method 'tarball'
+  version node['docker']['version']
+  action [:create, :start]
+end

--- a/test/integration/service_install_tarball-1111/inspec/assert_functioning_spec.rb
+++ b/test/integration/service_install_tarball-1111/inspec/assert_functioning_spec.rb
@@ -1,0 +1,5 @@
+
+describe command('/usr/bin/docker --version') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/1.11.1/) }
+end


### PR DESCRIPTION
### Description

Docker versions > 0.11 don't support binary installation, so tarball
installation must be used instead.

This change ensures you can use `docker_service` as a single action
to install via tarball, as previously this was missed.

### Issues Resolved

-

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [n/a] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

