### PR TITLE
option log_opt is defined as --log-opt value1 --log-opt value2 instea…

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -191,7 +191,7 @@ module DockerCookbook
         opts << "--log-level=#{log_level}" if log_level
         labels.each { |l| opts << "--label=#{l}" } if labels
         opts << "--log-driver=#{log_driver}" if log_driver
-        log_opts.each { |log_opt| opts << "--log-opt=#{log_opt}" } if log_opts
+        log_opts.each { |log_opt| opts << "--log-opt #{log_opt}" } if log_opts
         opts << "--mtu=#{mtu}" if mtu
         opts << "--pidfile=#{pidfile}" if pidfile
         opts << "--registry-mirror=#{registry_mirror}" if registry_mirror


### PR DESCRIPTION
option log_opt is defined as --log-opt value1 --log-opt value2 instead of --log-opt=value1 --log-opt=value2
### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

…d of --log-opt=value1 --log-opt=value2

Signed-off-by: Jean-Bernard Damiano <jdamiano.ext@orange.com>