### PR TITLE
Added ro_rootfs => ReadonlyRootfs special cases mapping

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -130,7 +130,7 @@ module DockerCookbook
       # Go through everything in the container and set corresponding properties:
       # c.info['Config']['ExposedPorts'] -> exposed_ports
       (container.info['Config'].to_a + container.info['HostConfig'].to_a).each do |key, value|
-        next if value.nil? || key == 'RestartPolicy' || key == 'Binds'
+        next if value.nil? || key == 'RestartPolicy' || key == 'Binds' || key == 'ReadonlyRootfs'
 
         # Image => image
         # Set exposed_ports = ExposedPorts (etc.)
@@ -142,6 +142,7 @@ module DockerCookbook
       restart_policy container.info['HostConfig']['RestartPolicy']['Name']
       restart_maximum_retry_count container.info['HostConfig']['RestartPolicy']['MaximumRetryCount']
       volumes_binds container.info['HostConfig']['Binds']
+      ro_rootfs container.info['HostConfig']['ReadonlyRootfs']
     end
 
     #########


### PR DESCRIPTION
### Description

This commit adds ReadonlyRootfs to the list of keys which are skipped in the automated load of state and then maps ro_rootfs to the ReadonlyRootfs manually as was done with other similar cases.

### Issues Resolved

The ro_rootfs property of the docker_container resource doesn't match the property in the docker HostConfig (called ReadonlyRootfs).
As a result, chef fails to properly load the value into the state of the current resource and forces a redeploy even when no change has been made.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

to prevent redeploying containers with ro_rootfs = true

Signed-off-by: Yonah Russ <me@yonahruss.com>