### PR TITLE
Enable systemd options as a docker_service attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ docker_service_manager_systemd 'default' do
   tls_server_key "/path/to/server-key.pem"
   tls_client_cert "/path/to/cert.pem"
   tls_client_key "/path/to/key.pem"
+  systemd_ops ["TasksMax=infinity","MountFlags=private"]
   action :start
 end
 ```
@@ -451,6 +452,10 @@ The `docker_service` resource property list mostly corresponds to the options fo
 #### Miscellaneous Options
 
 - `misc_opts` - Pass the docker daemon any other options bypassing flag validation, supplied as `--flag=value`
+
+#### Systemd-specific Options
+
+- `systemd_opts` - An array of strings that will be included as individual lines in the systemd service unit for Docker.  *Note*: This option is only relevant for systems where systemd is the default service manager or where systemd is specified explicitly as the service manager.   
 
 ### Actions
 

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -60,6 +60,11 @@ module DockerCookbook
     property :disable_legacy_registry, [Boolean, nil]
     property :userns_remap, [String, nil]
 
+    # These are options specific to systemd configuration such as
+    # LimitNOFILE or TasksMax that you may wannt to use to customize
+    # the environment in which Docker runs.
+    property :systemd_opts, ArrayType
+
     # These are unvalidated daemon arguments passed in as a string.
     property :misc_opts, [String, nil]
 

--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -58,6 +58,7 @@ module DockerCookbook
         variables(
           config: new_resource,
           docker_daemon_cmd: docker_daemon_cmd,
+          systemd_conf: systemd_conf,
           docker_wait_ready: "#{libexec_dir}/#{docker_name}-wait-ready"
         )
         cookbook 'docker'

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -162,6 +162,12 @@ module DockerCookbook
         opts
       end
 
+      def systemd_conf
+        opts = ''
+        systemd_opts.each { |systemd_opt| opts << "#{systemd_opt}\n" } if systemd_opts
+        opts
+      end
+
       def docker_daemon_opts
         opts = []
         opts << "--api-cors-header=#{api_cors_header}" if api_cors_header

--- a/templates/default/systemd/docker.service-override.erb
+++ b/templates/default/systemd/docker.service-override.erb
@@ -30,6 +30,7 @@ MountFlags=private
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
+<%= @systemd_conf  %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description

Modifies the template file and systemd service files to allow users to specify an array of Systemd options, such as "TasksMax=infinity" that need to go into the /etc/systemd/system/docker.service file.
    
Pull request #759 and associated issue #756 would be covered by this in that rather than assuming a default for MountFlags that would need to apply to all Docker service deployments in Chef, users could dictate these settings through an attribute/property of the docker_service resource or docker_service_manager resource without losing the other extremely useful features of the cookbook by having to rewrite that file with their own cookbooks.
    
It's not really right to assume that MountFlags will be the very last setting that developers will want to change in the systemd settings--the list of potential settings is extremely long and complex. Better to let the developer make the decision in his/her cookbook.

### Issues Resolved

#759 at least. But I'm sure many other systemd settings will come up if this is not resolved.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Ben Smith <benjsmi@us.ibm.com>