### PR TITLE
When stopping via execute, wait until Docker is fully stopped

### DIFF
--- a/libraries/docker_service_manager_execute.rb
+++ b/libraries/docker_service_manager_execute.rb
@@ -41,7 +41,8 @@ module DockerCookbook
 
     action :stop do
       execute "stop docker #{name}" do
-        command "kill `cat #{pidfile}`"
+        command "kill `cat #{pidfile}` && while [ -e #{pidfile} ]; do sleep 1; done"
+        timeout 10
         only_if "#{docker_cmd} ps | head -n 1 | grep ^CONTAINER"
       end
     end


### PR DESCRIPTION
### Description

I've only been able to reproduce this when doing Docker-in-Docker via
kitchen-docker, but there are cases where the restart can happen faster
than Docker can stop. There is a split second after killing the process
where the PID file still exists, and Docker will fail to start if the
PID file exists.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jonathan Hartman <j@p4nt5.com>