### PR TITLE
Require 12.5 and remove the need for compat_resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,6 @@ version '2.14.4'
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'
 
-depends 'compat_resource', '>= 12.16.2'
-
 supports 'amazon'
 supports 'centos'
 supports 'scientific'
@@ -19,4 +17,4 @@ supports 'fedora'
 supports 'redhat'
 supports 'ubuntu'
 
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 12.5' if respond_to?(:chef_version)


### PR DESCRIPTION
Avoid a pile of pain with compat_resource