### PR TITLE
Update syslog-tag mention in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ docker_container 'syslogger' do
   tag '3.1'
   command 'nc -ll -p 780 -e /bin/cat'
   log_driver 'syslog'
-  log_opts 'syslog-tag=container-syslogger'
+  log_opts 'tag=container-syslogger'
 end
 ```
 


### PR DESCRIPTION
### Description

Change the mention of `syslog-tag` to `tag` in the README.

### Issues Resolved

No existing issues, though https://github.com/Accenture/adop-docker-compose/issues/115 is revelant.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

I hate to be even putting in this PR for a one-word change, but it was a bit of a search before I figured out this was the issue. The related (but closed) issue is eight months old, so maybe the assumption of users running a newer docker version is safe?
