### PR TITLE
Add network_aliases support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,7 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `memory_swap` - Total memory limit (memory + swap); set `-1` to disable swap limit (unlimited). You must use this with memory and make the swap value larger than memory.
 - `network_disabled` - Boolean to disable networking. Defaults to `false`.
 - `network_mode` - Sets the networking mode for the container. One of `bridge`, `host`, `container`.
+- `network_aliases` - Adds network-scoped alias for the container in form `['alias-1', 'alias-2']`.
 - `open_stdin` - Boolean value, opens stdin. Defaults to `false`.
 - `outfile` - The path to write the file when using `:export` action.
 - `port` - The port configuration to use in the container. Matches the syntax used by the `docker` CLI tool.

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -67,6 +67,7 @@ module DockerCookbook
     property :memory_reservation, Integer, coerce: proc { |v| coerce_memory_reservation(v) }, default: 0
     property :network_disabled, Boolean, default: false
     property :network_mode, [String, NilClass], default: 'bridge'
+    property :network_aliases, [ArrayType], default: []
     property :open_stdin, Boolean, default: false, desired_state: false
     property :outfile, [String, NilClass]
     property :port_bindings, PartialHashType, default: {}
@@ -317,6 +318,7 @@ module DockerCookbook
                   'IPAMConfig' => {
                     'IPv4Address' => ip_address,
                   },
+                  'Aliases' => network_aliases,
                 },
               },
             },


### PR DESCRIPTION
### Description

Docker host_name actually doesn't set containers' hostname globally to
the docker network. But `--network-alias` does.
