### PR TITLE
Expose package_name through the docker_service resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ options found in the
 - `log_driver` - Container's logging driver (json-file/syslog/journald/gelf/fluentd/awslogs/splunk/etwlogs/gcplogs/none)
 - `log_opts` - Container's logging driver options (driver-specific)
 - `mtu` - Set the containers network MTU
+- `package_name` - Set the package name. Defaults to `docker-engine`
 - `pidfile` - Path to use for daemon PID file
 - `registry_mirror` - Preferred Docker registry mirror
 - `storage_driver` - Storage driver to use

--- a/libraries/docker_service.rb
+++ b/libraries/docker_service.rb
@@ -22,6 +22,7 @@ module DockerCookbook
 
     # docker_installation_package
     property :package_version, String, desired_state: false
+    property :package_name, String, desired_state: false
 
     # binary, package and tarball
     property :version, String, desired_state: false


### PR DESCRIPTION
### Description

When installing docker using a `package` value for the `install_method` attribute, the default package name `docker-engine` could not be altered and was incorrect for the Centos platform. Based on step 2 of [the centos install process](https://docs.docker.com/engine/installation/linux/centos/#install-docker-1) the `package_name` should be either `docker-ce` for community edition or `docker-ee` for the enterprise edition.

The PR does not attempt to alter existing functionality, only to expose the ability to customize the `package_name` property from the `docker_service` resource.

### Issues Resolved

None.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
