### PR TITLE
Remove support for Precise and Vivid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
 dist: trusty
 
-# install the pre-release chef-dk.  Use chef-stable-trusty to install the stable release
+# install the pre-release chef-dk.
 addons:
   apt:
     sources:
-      - chef-stable-trusty
+      - chef-current-trusty
     packages:
       - chefdk
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ aufs.
 
 ## Requirements
 
-- Chef 12.5.x or higher. Chef 11 is NOT SUPPORTED, please do not open issues about it.
-- Ruby 2.1 or higher (preferably, the Chef full-stack installer)
+- Chef 12.5.x or higher
 - Network accessible web server hosting the docker binary.
 - SELinux permissive/disabled if CentOS [Docker Issue #15498](https://github.com/docker/docker/issues/15498)
 
@@ -36,7 +35,6 @@ configuration of cgroups and storage back ends.
 | debian-8     | ✔     | ✔     | ✔     | ✔      | ✔      | ✔      | ✔      |
 | centos-7     | ✔     | ✔     | ✔     | ✔      | ✔      | ✔      | ✔      |
 | fedora       |       |       | ✔     | ✔      | ✔      | ✔      | ✔      |
-| ubuntu-12.04 | ✔     | ✔     | ✔     | ✔      | ✔      | ✔      | ✔      |
 | ubuntu-14.04 | ✔     | ✔     | ✔     | ✔      | ✔      | ✔      | ✔      |
 | ubuntu-16.04 |       |       |       |        | ✔      | ✔      | ✔      |
 

--- a/libraries/helpers_installation_package.rb
+++ b/libraries/helpers_installation_package.rb
@@ -26,19 +26,9 @@ module DockerCookbook
         false
       end
 
-      def precise?
-        return true if node['platform'] == 'ubuntu' && node['platform_version'] == '12.04'
-        false
-      end
-
       def trusty?
         return true if node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
         return true if node['platform'] == 'linuxmint' && node['platform_version'] =~ /^17\.[0-9]$/
-        false
-      end
-
-      def vivid?
-        return true if node['platform'] == 'ubuntu' && node['platform_version'] == '15.04'
         false
       end
 
@@ -89,9 +79,7 @@ module DockerCookbook
         return "#{v}#{edition}-1.fc#{node['platform_version'].to_i}" if fedora?
         return "#{v}#{edition}-0~#{debian_prefix}wheezy" if wheezy?
         return "#{v}#{edition}-0~#{debian_prefix}jessie" if jesse?
-        return "#{v}#{edition}-0~#{ubuntu_prefix}precise" if precise?
         return "#{v}#{edition}-0~#{ubuntu_prefix}trusty" if trusty?
-        return "#{v}#{edition}-0~#{ubuntu_prefix}vivid" if vivid?
         return "#{v}#{edition}-0~#{ubuntu_prefix}wily" if wily?
         return "#{v}#{edition}-0~#{ubuntu_prefix}xenial" if xenial?
         v
@@ -99,7 +87,6 @@ module DockerCookbook
 
       def default_docker_version
         return '1.7.1' if el6?
-        return '1.9.1' if vivid?
         return '1.12.6' if amazon?
         '17.04.0'
       end


### PR DESCRIPTION
These are both EOL and have old kernsl. Let them die

Signed-off-by: Tim Smith <tsmith@chef.io>