### PR TITLE
Fix for installing vendored gems from docker cookbook

### DIFF
--- a/libraries/_autoload.rb
+++ b/libraries/_autoload.rb
@@ -6,8 +6,10 @@ rescue LoadError
 
     require 'chef/resource/chef_gem'
 
-    docker = Chef::Resource::ChefGem.new('docker-api', run_context)
-    docker.version '= 1.33.2'
+    vendored_gems = *Dir[File.expand_path('../../files/default/vendor/cache/*.gem', __FILE__)]
+    gems = vendored_gems.join('" "')
+    docker = Chef::Resource::ChefGem.new(gems, run_context)
+    docker.options '--local'
     docker.run_action(:install)
   end
 end


### PR DESCRIPTION
Fix for installing vendored gems from docker cookbook that works when api.rubygems.org is not reachable.

### Description

This is a slightly hacky way to resolve the problem mentioned in #860.

Since `gem` doesn't provide enough options to simulate all rubygems behavior (dependency resolution / version constraints in --local mode), and because Chef::Resources::ChefGem doesn't provide options to specify an array of gems to be installed, `.join('" "')` is used against a glob of the bundled gems to install them all in one go.

A better solution might be to use bundler to install the vendored gems, but Chef doesn't appear to provide a convenient resource for this.

### Issues Resolved

#860

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
