### PR TITLE
Bug: Change kill_after property default value to nil

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -100,9 +100,9 @@ module DockerCookbook
     property :container, Docker::Container, desired_state: false
 
     # Used by :stop action. If the container takes longer than this
-    # many seconds to stop, kill itinstead. -1 (the default) means
+    # many seconds to stop, kill it instead. A nil value (the default) means
     # never kill the container.
-    property :kill_after, Numeric, default: -1, desired_state: false
+    property :kill_after, [Integer, NilClass], default: nil, desired_state: false
 
     alias cmd command
     alias additional_host extra_hosts
@@ -344,7 +344,7 @@ module DockerCookbook
 
     action :stop do
       return unless state['Running']
-      kill_after_str = " (will kill after #{kill_after}s)" if kill_after != -1
+      kill_after_str = "(will kill after #{kill_after}s)" if kill_after
       converge_by "stopping #{container_name} #{kill_after_str}" do
         begin
           with_retries do


### PR DESCRIPTION
### Description

I was getting read timeout errors when using the :restart action on multiple docker_container resources in the same run.

```
           Docker::Error::TimeoutError
           ---------------------------
           read timeout reached

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/docker/libraries/docker_container.rb:396:in `block (2 levels) in \<class:DockerContainer\>'
```

Noticed that the default value of the 'kill_after' property on the docker_container resource was '-1'.    When looking at the docker-api gem code (https://github.com/swipely/docker-api/blob/v1.33.1/lib/docker/container.rb#L229-L235) saw that this would now force set 'read_timeout' and 'write_timeout' to 4 seconds.   Looks like 'nil' would be the proper default value to use for the documented default behavior of never killing the container (with recent versions of the docker-api gem).

### Issues Resolved

No existing open issue found.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>