### PR TITLE
Only use --raw-logs argument in versions which support it

### DIFF
--- a/libraries/docker_service_manager_upstart.rb
+++ b/libraries/docker_service_manager_upstart.rb
@@ -23,6 +23,7 @@ module DockerCookbook
           docker_name: docker_name,
           dockerd_bin_link: dockerd_bin_link,
           docker_daemon_arg: docker_daemon_arg,
+          docker_raw_logs_arg: docker_raw_logs_arg,
           docker_wait_ready: "#{libexec_dir}/#{docker_name}-wait-ready"
         )
         cookbook 'docker'

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -138,6 +138,14 @@ module DockerCookbook
         end
       end
 
+      def docker_raw_logs_arg
+        if Gem::Version.new(docker_major_version) < Gem::Version.new('1.11')
+          ''
+        else
+          '--raw-logs'
+        end
+      end
+
       def docker_daemon_cmd
         [dockerd_bin, docker_daemon_arg, docker_daemon_opts].join(' ')
       end

--- a/templates/default/upstart/docker.conf.erb
+++ b/templates/default/upstart/docker.conf.erb
@@ -39,7 +39,7 @@ script
     if [ -f /etc/default/$UPSTART_JOB ]; then
         . /etc/default/$UPSTART_JOB
     fi
-    exec "$DOCKER" <%= @docker_daemon_arg %> $DOCKER_OPTS --raw-logs
+    exec "$DOCKER" <%= @docker_daemon_arg %> $DOCKER_OPTS <%= @docker_raw_logs_arg %>
 end script
 
 post-start script


### PR DESCRIPTION
### Description

The upstart config in this cookbook includes the daemon argument `--raw-logs`, which is only valid in docker-engine versions after [1.11.0](https://github.com/moby/moby/blob/89658be/CHANGELOG.md#logging-6), however the argument is currently hard coded, breaking the docker daemon on any upstart using system running docker daemons prior to version 1.11.0.

This change adds a `docker_raw_logs_arg` helper which enables or disables the raw-logs argument depending on the version used. This changeset updates the upstart template to make use of the `docker_raw_logs_arg` helper.

### Issues Resolved

https://github.com/chef-cookbooks/docker/issues/839

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] [N/A] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>


---

Regarding testing: I'm unfamiliar with kitchen and InSpec. Can I get some guidance on where to add tests here? Is testing for older versions of docker even required?