### PR TITLE
Add systemctl restart resource and appropriate notifications.

### DIFF
--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -50,6 +50,12 @@ module DockerCookbook
         not_if { docker_name == 'default' && ::File.exist?('/lib/systemd/system/docker.socket') }
       end
 
+      # restart if changes in template resources
+      execute "systemctl restart #{docker_name}" do
+        command "/bin/systemctl restart #{docker_name}"
+        action :nothing
+      end
+
       template "/etc/systemd/system/#{docker_name}.service" do
         source 'systemd/docker.service-override.erb'
         owner 'root'
@@ -64,6 +70,7 @@ module DockerCookbook
         )
         cookbook 'docker'
         notifies :run, 'execute[systemctl daemon-reload]', :immediately
+        notifies :run, "execute[systemctl restart #{docker_name}]", :immediately
         action :create
       end
 
@@ -80,6 +87,7 @@ module DockerCookbook
         )
         cookbook 'docker'
         notifies :run, 'execute[systemctl daemon-reload]', :immediately
+        notifies :run, "execute[systemctl restart #{docker_name}]", :immediately
         action :create
       end
 

--- a/test/cookbooks/docker_test/recipes/smoke.rb
+++ b/test/cookbooks/docker_test/recipes/smoke.rb
@@ -43,20 +43,20 @@ template '/etc/squid_forward_proxy/squid.conf' do
   action :create
 end
 
-docker_image 'someara/squid' do
+docker_image 'cbolt/squid' do
   tag 'latest'
   action :pull
 end
 
 docker_container 'squid_forward_proxy' do
-  repo 'someara/squid'
+  repo 'cbolt/squid'
   tag 'latest'
   restart_policy 'on-failure'
   kill_after 5
   port '3128:3128'
   command '/usr/sbin/squid -NCd1'
   volumes '/etc/squid_forward_proxy/squid.conf:/etc/squid/squid.conf'
-  subscribes :redeploy, 'docker_image[someara/squid]'
+  subscribes :redeploy, 'docker_image[cbolt/squid]'
   action :run
 end
 


### PR DESCRIPTION
### Description

Adds a systemctl restart resource so that changes in docker_service properties restarts the service. 

### Issues Resolved

#849 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
