### PR TITLE
Only restart docker.service once both docker.service and docker.socke…

### DIFF
--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -69,7 +69,7 @@ module DockerCookbook
         )
         cookbook 'docker'
         notifies :run, 'execute[systemctl daemon-reload]', :immediately
-        notifies :run, "execute[systemctl restart #{docker_name}]", :immediately
+        notifies :run, "execute[systemctl restart #{docker_name}]", :delayed
         action :create
       end
 
@@ -86,7 +86,7 @@ module DockerCookbook
         )
         cookbook 'docker'
         notifies :run, 'execute[systemctl daemon-reload]', :immediately
-        notifies :run, "execute[systemctl restart #{docker_name}]", :immediately
+        notifies :run, "execute[systemctl restart #{docker_name}]", :delayed
         action :create
       end
 


### PR DESCRIPTION
…t overrides have been updated

### Description

There was a problem with the way that the systemd unit customizations for docker.service and docker.socket were applied. When changing attributes that affect the socket, namely the socket group, docker.service would be restarted before the overrides to the docker.socket unit were applied. This would cause docker.socket to fail to start and thus docker.service to fail to start.

This change just delays the restarting of docker.service and docker.socket to allow both overrides to be applied before attempting to restart these systemd units.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
