### PR TITLE
docker_network: support ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1274,6 +1274,7 @@ end
   `192.168.0.1`
 - `ip_range` - Specify a range of IPs to allocate for containers. Ex:
   `192.168.1.0/24`
+- `enable_ipv6` - Enable IPv6 on the network. Ex: true
 - `aux_address` - Auxillary addresses for the network. Ex:
   `['a=192.168.1.5', 'b=192.168.1.6']`
 - `container` - Container-id/name to be connected/disconnected to/from
@@ -1315,6 +1316,16 @@ end
 docker_network 'network_h2' do
   container 'echo-base-networks_h'
   action :connect
+end
+```
+
+IPv6 enabled network
+
+```ruby
+docker_network 'network_i1' do
+  enable_ipv6 true
+  subnet 'fd00:dead:beef::/48'
+  action :create
 end
 ```
 

--- a/libraries/docker_network.rb
+++ b/libraries/docker_network.rb
@@ -10,9 +10,11 @@ module DockerCookbook
     property :container, String, desired_state: false
     property :driver, String
     property :driver_opts, PartialHashType
+    property :enable_ipv6, [Boolean, nil]
     property :gateway, [String, Array, nil], coerce: proc { |v| coerce_gateway(v) }
     property :host, [String, nil], default: lazy { default_host }, desired_state: false
     property :id, String
+    property :internal, [Boolean, nil]
     property :ip_range, [String, Array, nil], coerce: proc { |v| coerce_ip_range(v) }
     property :ipam_driver, String
     property :network, Docker::Network, desired_state: false
@@ -68,6 +70,8 @@ module DockerCookbook
           ipam_options = consolidate_ipam(subnet, ip_range, gateway, aux_address)
           options['IPAM'] = { 'Config' => ipam_options } unless ipam_options.empty?
           options['IPAM']['Driver'] = ipam_driver if ipam_driver
+          options['EnableIPv6'] = enable_ipv6 if enable_ipv6
+          options['Internal'] = internal if internal
           Docker::Network.create(network_name, options)
         end
       end

--- a/libraries/helpers_network.rb
+++ b/libraries/helpers_network.rb
@@ -92,7 +92,6 @@ module DockerCookbook
             data[s]['Gateway'] = g
             match = true
           end
-          raise "no matching subnet for gateway #{s}" unless match
         end
 
         auxaddrs.each do |aa|

--- a/spec/docker_test/network_spec.rb
+++ b/spec/docker_test/network_spec.rb
@@ -151,4 +151,25 @@ describe 'docker_test::network' do
       )
     end
   end
+
+  context 'ipv6 network' do
+    it 'creates docker_network_ipv6' do
+      expect(chef_run).to create_docker_network('network_ipv6').with(
+        enable_ipv6: true,
+        subnet: 'fd00:dead:beef::/48'
+      )
+    end
+
+    it 'creates docker_network_ipv4' do
+      expect(chef_run).to create_docker_network('network_ipv4')
+    end
+  end
+
+  context 'internal network' do
+    it 'creates docker_network_internal' do
+      expect(chef_run).to create_docker_network('network_internal').with(
+        internal: true
+      )
+    end
+  end
 end

--- a/test/cookbooks/docker_test/recipes/network.rb
+++ b/test/cookbooks/docker_test/recipes/network.rb
@@ -225,3 +225,28 @@ docker_network 'network_h1 disconnector' do
   network_name 'network_h1'
   action :disconnect
 end
+
+##############
+# network_ipv6
+##############
+# IPv6 enabled network
+docker_network 'network_ipv6' do
+  enable_ipv6 true
+  subnet 'fd00:dead:beef::/48'
+  action :create
+end
+
+##############
+# network_ipv4
+##############
+docker_network 'network_ipv4' do
+  action :create
+end
+
+##################
+# network_internal
+##################
+docker_network 'network_internal' do
+  internal true
+  action :create
+end

--- a/test/integration/network/inspec/assert_functioning_spec.rb
+++ b/test/integration/network/inspec/assert_functioning_spec.rb
@@ -193,6 +193,58 @@ describe command("docker network inspect -f '{{ range $c:=.Containers }}{{ $c.Na
   its(:stdout) { should match 'container1-network_h' }
 end
 
+##############
+# network_ipv4
+##############
+
+describe command("docker network ls -qf 'name=network_ipv4$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not be_empty }
+end
+
+describe command("docker network inspect -f '{{ .EnableIPv6 }}' network_ipv4") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match 'false' }
+end
+
+describe command("docker network inspect -f '{{ .Internal }}' network_ipv4") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match 'false' }
+end
+
+##############
+# network_ipv6
+##############
+
+describe command("docker network ls -qf 'name=network_ipv6$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not be_empty }
+end
+
+describe command("docker network inspect -f '{{ .EnableIPv6 }}' network_ipv6") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match 'true' }
+end
+
+describe command("docker network inspect -f '{{ range $i:=.IPAM.Config }}{{ .Subnet | printf \"%s\\n\" }}{{ end }}' network_ipv6") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should include 'fd00:dead:beef::/48' }
+end
+
+##################
+# network_internal
+##################
+
+describe command("docker network ls -qf 'name=network_internal'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not be_empty }
+end
+
+describe command("docker network inspect -f '{{ .Internal }}' network_internal") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match 'true' }
+end
+
 # describe command('docker network inspect test-network') do
 #   its(:exit_status) { should eq 0 }
 # end


### PR DESCRIPTION
### Description

allow setting the [EnableIPv6](https://docs.docker.com/engine/api/v1.30/#operation/NetworkCreate) option to create networks with IPv6 support.


