### PR TITLE
Support correctly centos as well

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -46,7 +46,7 @@ module DockerCookbook
       end
 
       def default_group
-        platform?('redhat') ? 'dockerroot' : 'docker'
+        platform_family?('rhel') ? 'dockerroot' : 'docker'
       end
 
       def installed_docker_version


### PR DESCRIPTION
### Description

Correctly default to dockerroot group on all rhel family. Previous patch was working only on redhat


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
