### PR TITLE
Stop and start upstart service instead of restarting

### DIFF
--- a/libraries/docker_service_manager_upstart.rb
+++ b/libraries/docker_service_manager_upstart.rb
@@ -26,7 +26,8 @@ module DockerCookbook
           docker_wait_ready: "#{libexec_dir}/#{docker_name}-wait-ready",
           docker_socket: connect_socket
         )
-        notifies :restart, "service[#{docker_name}]", :immediately
+        notifies :stop, "service[#{docker_name}]", :immediately
+        notifies :start, "service[#{docker_name}]", :immediately
       end
 
       template "/etc/default/#{docker_name}" do


### PR DESCRIPTION
### Description

When changing a /etc/init/<service>.conf file, restart won't get the new config.
Only running stop, and then start will get the latest config from disk.

http://upstart.ubuntu.com/cookbook/#restart