### PR TITLE
Remove duplicate `labels` description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,6 @@ options found in the
 - `log_level` - Set the logging level
 - `labels` A string or array to set metadata on the daemon in the form ['foo:bar', 'hello:world']`
 - `log_driver` - Container's logging driver (json-file/syslog/journald/gelf/fluentd/none)
-- `labels` A string or array to set metadata on the daemon in the form ['foo:bar', 'hello:world']`
 - `log_driver` - Container's logging driver (json-file/syslog/journald/gelf/fluentd/awslogs/splunk/etwlogs/gcplogs/none)
 - `log_opts` - Container's logging driver options (driver-specific)
 - `mtu` - Set the containers network MTU


### PR DESCRIPTION
### Description

Removes a duplicate description for an option in service. README change only
