### PR TITLE
If the /etc/sysconfig file changes, restart Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the docker cookbook.
 
+## 2.15.27 (2017-08-25)
+- Restart RHEL sysvinit service on /etc/sysconfig/docker change
+
 ## 2.15.26 (2017-08-25)
 - bumping to 17.06.1
 - support for debian 9

--- a/libraries/docker_service_manager_sysvinit_rhel.rb
+++ b/libraries/docker_service_manager_sysvinit_rhel.rb
@@ -67,6 +67,7 @@ module DockerCookbook
           )
           cookbook 'docker'
           action :create
+          notifies :restart, "service[#{docker_name}]", :immediately
         end
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Cookbook Engineering Team'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Provides docker_service, docker_image, and docker_container resources'
-version '2.15.26'
+version '2.15.27'
 
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'


### PR DESCRIPTION
Signed-off-by: Kieren Hynd <kieren.hynd@ticketmaster.co.uk>

### Description
Similar to some of the other service providers, if the RHEL sysvinit provider changes the /etc/sysconfig/docker file, restart the service.  Otherwise if we're using docker_service to set any docker_daemon_opts, they don't get picked up.