### PR TITLE
Remove support for EOL non-LTS Ubuntu distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ configuration of cgroups and storage back ends.
 
 ## Cookbook Dependencies
 
-This cookbook has a loose dependency on the official docker repositories, which can be installed with `chef-apt-docker` or `chef-yum-docker`. You may choose to use your OS version of docker, but you may run into issues such as the docker group being named differently.
+This cookbook has a loose dependency on the official docker repositories, which can be installed with [chef-apt-docker](https://supermarket.chef.io/cookbooks/chef-apt-docker) or [chef-yum-docker](https://supermarket.chef.io/cookbooks/chef-yum-docker) cookbooks. You may choose to use your OS version of docker, but you may run into issues such as the docker group being named differently.
 
 ## Docker Group
 

--- a/libraries/helpers_installation_package.rb
+++ b/libraries/helpers_installation_package.rb
@@ -17,8 +17,7 @@ module DockerCookbook
       end
 
       def debuntu?
-        return true if node['platform'] == 'debian'
-        return true if node['platform'] == 'ubuntu'
+        return true if node['platform_family'] == 'debian'
         false
       end
 

--- a/libraries/helpers_installation_package.rb
+++ b/libraries/helpers_installation_package.rb
@@ -46,16 +46,6 @@ module DockerCookbook
         false
       end
 
-      def vivid?
-        return true if node['platform'] == 'ubuntu' && node['platform_version'] == '15.04'
-        false
-      end
-
-      def wily?
-        return true if node['platform'] == 'ubuntu' && node['platform_version'] == '15.10'
-        false
-      end
-
       def xenial?
         return true if node['platform'] == 'ubuntu' && node['platform_version'] == '16.04'
         false
@@ -108,10 +98,6 @@ module DockerCookbook
                        '-precise'
                      elsif trusty?
                        '-trusty'
-                     elsif vivid?
-                       '-vivid'
-                     elsif wily?
-                       '-wily'
                      elsif xenial?
                        '-xenial'
                      elsif zesty?


### PR DESCRIPTION
There's no excuse to be running a non-LTS EOL distro at this point.