### PR TITLE
Simplify resource provides and remove support for Ubuntu Precise

### DIFF
--- a/libraries/docker_service_manager_execute.rb
+++ b/libraries/docker_service_manager_execute.rb
@@ -2,8 +2,6 @@ module DockerCookbook
   class DockerServiceManagerExecute < DockerServiceBase
     resource_name :docker_service_manager_execute
 
-    provides :docker_service_manager, os: 'linux'
-
     # Start the service
     action :start do
       # enable ipv4 forwarding

--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -2,18 +2,8 @@ module DockerCookbook
   class DockerServiceManagerSystemd < DockerServiceBase
     resource_name :docker_service_manager_systemd
 
-    provides :docker_service_manager, platform: 'fedora'
-
-    provides :docker_service_manager, platform: %w(redhat centos scientific oracle) do |node| # ~FC005
-      node['platform_version'].to_f >= 7.0
-    end
-
-    provides :docker_service_manager, platform: 'debian' do |node|
-      node['platform_version'].to_f >= 8.0
-    end
-
-    provides :docker_service_manager, platform: 'ubuntu' do |node|
-      node['platform_version'].to_f >= 15.04
+    provides :docker_service_manager, os: 'linux' do |_node|
+      Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
     end
 
     action :start do

--- a/libraries/docker_service_manager_sysvinit_debian.rb
+++ b/libraries/docker_service_manager_sysvinit_debian.rb
@@ -6,16 +6,8 @@ module DockerCookbook
       node['platform_version'].to_f < 8.0
     end
 
-    provides :docker_service_manager, platform: 'ubuntu' do |node|
-      node['platform_version'].to_f < 12.04
-    end
-
     provides :docker_service_manager_sysvinit, platform: 'debian' do |node|
       node['platform_version'].to_f < 8.0
-    end
-
-    provides :docker_service_manager_sysvinit, platform: 'ubuntu' do |node|
-      node['platform_version'].to_f < 12.04
     end
 
     action :start do

--- a/libraries/docker_service_manager_upstart.rb
+++ b/libraries/docker_service_manager_upstart.rb
@@ -2,8 +2,10 @@ module DockerCookbook
   class DockerServiceManagerUpstart < DockerServiceBase
     resource_name :docker_service_manager_upstart
 
-    provides :docker_service_manager, platform: 'ubuntu'
-    provides :docker_service_manager, platform: 'linuxmint'
+    provides :docker_service_manager, platform_family: 'debian' do |_node|
+      Chef::Platform::ServiceHelpers.service_resource_providers.include?(:upstart) &&
+        !Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
+    end
 
     action :start do
       create_docker_wait_ready

--- a/libraries/helpers_installation_package.rb
+++ b/libraries/helpers_installation_package.rb
@@ -36,11 +36,6 @@ module DockerCookbook
         false
       end
 
-      def precise?
-        return true if node['platform'] == 'ubuntu' && node['platform_version'] == '12.04'
-        false
-      end
-
       def trusty?
         return true if node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
         false
@@ -94,8 +89,6 @@ module DockerCookbook
                        '-jessie'
                      elsif stretch?
                        '-stretch'
-                     elsif precise?
-                       '-precise'
                      elsif trusty?
                        '-trusty'
                      elsif xenial?
@@ -119,7 +112,6 @@ module DockerCookbook
       def default_docker_version
         return '1.7.1' if el6?
         return '17.06.2' if amazon?
-        return '17.04.0' if precise?
         '17.09.0'
       end
 


### PR DESCRIPTION
Precise has been EOL since April and the provides logic can be both simplified and expanded to support addition distros.