### PR TITLE
load internal and ipv6 status for existing docker_network resources

### DIFF
--- a/libraries/docker_network.rb
+++ b/libraries/docker_network.rb
@@ -57,6 +57,8 @@ module DockerCookbook
 
       driver network.info['Driver']
       driver_opts network.info['Options']
+      internal network.info['Internal']
+      enable_ipv6 network.info['EnableIPv6']
     end
 
     action :create do


### PR DESCRIPTION
Signed-off-by: Matt Kulka <mkulka@parchment.com>

### Description

These attributes currently default to nil every time the resource is loaded during each Chef run causing an attempt to destroy and recreate the network. This will load the state for these attributes from the Docker API response.

### Issues Resolved

Fix #951 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
