### PR TITLE
Update Amazon Linux package to docker-17.09.1ce-1.111.amzn1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -108,13 +108,13 @@ suites:
 # docker_installation_package resource
 ######################################
 
-- name: installation_package-17062
+- name: installation_package-17091
   includes: [
     'amazonlinux', # for dokken
     ]
   attributes:
     docker:
-      version: '17.06.2'
+      version: '17.09.1'
   run_list:
   - recipe[docker_test::installation_package]
 

--- a/libraries/helpers_installation_package.rb
+++ b/libraries/helpers_installation_package.rb
@@ -102,7 +102,7 @@ module DockerCookbook
 
         return "#{v}#{edition}-1.el6" if el6?
         return "#{v}#{edition}-1.el7.centos" if el7?
-        return "#{v}#{edition}-1.94.amzn1" if amazon?
+        return "#{v}#{edition}-1.111.amzn1" if amazon?
         return "#{v}#{edition}-1.fc#{node['platform_version'].to_i}" if fedora?
         return "#{v}#{edition}-0~#{debian_prefix}#{codename}" if node['platform'] == 'debian'
         return "#{v}#{edition}-0~#{ubuntu_prefix}#{codename}" if node['platform'] == 'ubuntu'
@@ -111,7 +111,7 @@ module DockerCookbook
 
       def default_docker_version
         return '1.7.1' if el6?
-        return '17.06.2' if amazon?
+        return '17.09.1' if amazon?
         '17.12.0'
       end
 

--- a/test/integration/installation_package-17091/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_package-17091/inspec/assert_functioning_spec.rb
@@ -1,5 +1,5 @@
 
 describe command('/usr/bin/docker --version') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/17.06.2/) }
+  its(:stdout) { should match(/17.09.1/) }
 end


### PR DESCRIPTION
### Description

Package `docker-17.09.1ce-1.111.amzn1` is available on Amazon Linux from the amzn-updates repository but the cookbook is still defaulting to `docker-17.06.2ce-1.94.amzn1`.

This PR attempts to update the default package version installed on Amazon Linux.

Thank you very much for your patience :-)

### Issues Resolved

#960
