### PR TITLE
Adding 'runtime' config option to 'docker_container'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,8 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `remove_volumes` - A boolean to clean up "dangling" volumes when removing the last container with a reference to it. Default to `false` to match the Docker CLI behavior.
 - `restart_policy` - One of `no`, `on-failure`, `unless-stopped`, or `always`. Use `always` if you want a service container to survive a Dockerhost reboot. Defaults to `no`.
 - `restart_maximum_retry_count` - Maximum number of restarts to try when `restart_policy` is `on-failure`. Defaults to an ever increasing delay (double the previous delay, starting at 100mS), to prevent flooding the server.
-- `running_wait_time` - Amount of seconds `docker_container` wait to determine if a process is running.`
+- `running_wait_time` - Amount of seconds `docker_container` wait to determine if a process is running.
+- `runtime` - Runtime to use when running container. Defaults to `runc`.
 - `security_opt` - A list of string values to customize labels for MLS systems, such as SELinux.
 - `signal` - The signal to send when using the `:kill` action. Defaults to `SIGTERM`.
 - `sysctls` - A hash of sysctls to set on the container. Defaults to `{}`.

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -61,6 +61,7 @@ module DockerCookbook
     property :remove_volumes, Boolean
     property :restart_maximum_retry_count, Integer, default: 0
     property :restart_policy, String
+    property :runtime, String, default: 'runc'
     property :ro_rootfs, Boolean, default: false
     property :security_opt, [String, ArrayType]
     property :signal, String, default: 'SIGTERM'
@@ -291,6 +292,7 @@ module DockerCookbook
                 'MaximumRetryCount' => new_resource.restart_maximum_retry_count,
               },
               'ReadonlyRootfs'  => new_resource.ro_rootfs,
+              'Runtime'         => new_resource.runtime,
               'SecurityOpt'     => new_resource.security_opt,
               'Sysctls'         => new_resource.sysctls,
               'Ulimits'         => new_resource.ulimits_to_hash,


### PR DESCRIPTION
### Description

Adds ability to set `runtime` argument when running a container (ie. [https://hackernoon.com/docker-containerd-standalone-runtimes-heres-what-you-should-know-b834ef155426](https://hackernoon.com/docker-containerd-standalone-runtimes-heres-what-you-should-know-b834ef155426))

### Issues Resolved

No issues resolved... only a feature addition.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
