### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `pid_mode` - Set the PID (Process) Namespace mode for the container. `host`: use the host's PID namespace inside the container.
 - `ipc_mode` - Set the IPC mode for the container - Defaults to `nil`, example option: `host`
 - `uts_mode` - Set the UTS namespace mode for the container. The UTS namespace is for setting the hostname and the domain that is visible to running processes in that namespace. By default, all containers, including those with `--network=host`, have their own UTS namespace. The host setting will result in the container using the same UTS namespace as the host. Note that --hostname is invalid in host UTS mode.
-- `ro_rootfs` - Mount the container's root filesystem as read only. Defaults to `false`
+- `ro_rootfs` - Mount the container's root filesystem as read only using the `--read-only` flag. Defaults to `false`
 
 ### Examples
 


### PR DESCRIPTION
Make the `ro_rootfs` option easier to find by mentioning the docker flag.