### PR TITLE
Flag registry password property as sensitive in docker_registry resource

### DIFF
--- a/libraries/docker_registry.rb
+++ b/libraries/docker_registry.rb
@@ -6,7 +6,7 @@ module DockerCookbook
     resource_name :docker_registry
 
     property :email, [String, nil]
-    property :password, [String, nil]
+    property :password, [String, nil], sensitive: true
     property :serveraddress, [String, nil], name_property: true
     property :username, [String, nil]
 


### PR DESCRIPTION
### Description

This PR adds the sensitive flag to the password property of the docker_registry resource, so the password doesn't show up in logs or on stdout.
