### PR TITLE
Added oom_kill_disable and oom_score_adj support to docker_container

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,8 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `network_disabled` - Boolean to disable networking. Defaults to `false`.
 - `network_mode` - Sets the networking mode for the container. One of `bridge`, `host`, `container`.
 - `network_aliases` - Adds network-scoped alias for the container in form `['alias-1', 'alias-2']`.
+- `oom_kill_disable` - Whether to disable OOM Killer for the container or not.
+- `oom_score_adj` - Tune container's OOM preferences (-1000 to 1000).
 - `open_stdin` - Boolean value, opens stdin. Defaults to `false`.
 - `outfile` - The path to write the file when using `:export` action.
 - `port` - The port configuration to use in the container. Matches the syntax used by the `docker` CLI tool.

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -46,6 +46,8 @@ module DockerCookbook
     property :network_disabled, [TrueClass, FalseClass], default: false
     property :network_mode, [String, NilClass], default: 'bridge'
     property :network_aliases, [ArrayType], default: []
+    property :oom_kill_disable, [TrueClass, FalseClass], default: false
+    property :oom_score_adj, [Integer, nil], default: -500
     property :open_stdin, [TrueClass, FalseClass], default: false, desired_state: false
     property :outfile, [String, NilClass]
     property :port_bindings, PartialHashType, default: {}
@@ -497,6 +499,8 @@ module DockerCookbook
               'MemorySwappiness' => new_resource.memory_swappiness,
               'MemoryReservation' => new_resource.memory_reservation,
               'NetworkMode'     => new_resource.network_mode,
+              'OomKillDisable'  => new_resource.oom_kill_disable,
+              'OomScoreAdj'     => new_resource.oom_score_adj,
               'Privileged'      => new_resource.privileged,
               'PidMode'         => new_resource.pid_mode,
               'PortBindings'    => new_resource.port_bindings,

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -984,6 +984,32 @@ docker_container 'kill_after' do
   action :stop
 end
 
+######
+# oom_kill_disable
+######
+
+docker_container 'oom_kill_disable' do
+  repo 'alpine'
+  tag '3.1'
+  command 'ls -la'
+  oom_kill_disable true
+  timeout 40
+  action :run_if_missing
+end
+
+######
+# oom_score_adj
+######
+
+docker_container 'oom_score_adj' do
+  repo 'alpine'
+  tag '3.1'
+  command 'ls -la'
+  oom_score_adj 600
+  timeout 40
+  action :run_if_missing
+end
+
 ##########
 # pid_mode
 ##########

--- a/test/integration/resources/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources/inspec/assert_functioning_spec.rb
@@ -660,6 +660,30 @@ describe command("docker inspect -f '{{ .HostConfig.NetworkMode }}' network_mode
   its(:stdout) { should match(/host/) }
 end
 
+# docker_container[oom_kill_disable]
+
+describe command("docker ps -af 'name=oom_kill_disable$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.OomKillDisable }}' oom_kill_disable") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { eq 'true' }
+end
+
+# docker_container[oom_score_adj]
+
+describe command("docker ps -af 'name=oom_score_adj$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/Exited \(0\)/) }
+end
+
+describe command("docker inspect --format '{{ .HostConfig.OomScoreAdj }}' oom_score_adj") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/600/) }
+end
+
 # docker_container[ulimits]
 describe docker_container('ulimits') do
   it { should exist }


### PR DESCRIPTION
### Description

Added **oom_kill_disable** and **oom_score_adj** support to docker_container.

https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources
https://docs.docker.com/config/containers/resource_constraints/#memory
