### PR TITLE
 #999: docker service :log_level property converted to String.

### DIFF
--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -47,7 +47,7 @@ module DockerCookbook
     property :ip_masq, [TrueClass, FalseClass]
     property :iptables, [TrueClass, FalseClass]
     property :ipv6, [TrueClass, FalseClass]
-    property :log_level, [:debug, :info, :warn, :error, :fatal, nil]
+    property :log_level, %w(debug info warn error fatal), default: 'info'
     property :labels, [String, Array], coerce: proc { |v| coerce_daemon_labels(v) }, desired_state: false
     property :log_driver, %w(json-file syslog journald gelf fluentd awslogs splunk none)
     property :log_opts, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }


### PR DESCRIPTION
### Description

provides a fix to set :log_level for dockers' syslog driver.

### Issues Resolved

#999 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
