### PR TITLE
Use new package versioning scheme for bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,11 @@ services: docker
 env:
   matrix:
   - INSTANCE=installation-script-main-ubuntu-1604
+  - INSTANCE=installation-script-main-ubuntu-1804
   - INSTANCE=installation-tarball-ubuntu-1604
+  - INSTANCE=installation-tarball-ubuntu-1804
   - INSTANCE=installation-package-ubuntu-1604
+  - INSTANCE=installation-package-ubuntu-1804
   - INSTANCE=registry-ubuntu-1604
   - INSTANCE=network-ubuntu-1604
   - INSTANCE=volume-ubuntu-1604
@@ -30,6 +33,7 @@ env:
   - INSTANCE=resources-fedora-28
   - INSTANCE=resources-ubuntu-1404
   - INSTANCE=resources-ubuntu-1604
+  - INSTANCE=resources-ubuntu-1804
 
 # Ensure we make ChefDK's Ruby the default
 before_script:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -101,14 +101,14 @@ suites:
 - name: installation_package
   attributes:
     docker:
-      version: '18.03.0'
+      version: '18.03.1'
   run_list:
   - recipe[docker_test::installation_package]
 
 - name: installation_tarball
   attributes:
     docker:
-      version: '18.03.0'
+      version: '18.03.1'
   run_list:
   - recipe[docker_test::installation_tarball]
   includes: [
@@ -122,7 +122,7 @@ suites:
 - name: resources
   attributes:
     docker:
-      version: '18.03.0'
+      version: '18.03.1'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::image]
@@ -135,7 +135,7 @@ suites:
    ]
   attributes:
     docker:
-      version: '18.03.0'
+      version: '18.03.1'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::network]
@@ -146,7 +146,7 @@ suites:
    ]
   attributes:
     docker:
-      version: '18.03.0'
+      version: '18.03.1'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::volume]
@@ -157,7 +157,7 @@ suites:
    ]
   attributes:
     docker:
-      version: '18.03.0'
+      version: '18.03.1'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::registry]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -71,6 +71,7 @@ suites:
 - name: installation_script_main
   includes: [
     'ubuntu-16.04',
+    'ubuntu-18.04'
    ]
   attributes:
     docker:
@@ -81,6 +82,7 @@ suites:
 - name: installation_script_test
   includes: [
     'ubuntu-16.04',
+    'ubuntu-18.04'
    ]
   attributes:
     docker:
@@ -91,6 +93,7 @@ suites:
 - name: installation_script_experimental
   includes: [
     'ubuntu-16.04',
+    'ubuntu-18.04'
    ]
   attributes:
     docker:
@@ -113,6 +116,7 @@ suites:
   - recipe[docker_test::installation_tarball]
   includes: [
     'ubuntu-16.04',
+    'ubuntu-18.04'
    ]
 
 ##################
@@ -169,6 +173,7 @@ suites:
 - name: smoke
   includes: [
     'ubuntu-16.04',
+    'ubuntu-18.04'
    ]
   run_list:
   - recipe[docker_test::smoke]

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -54,7 +54,7 @@ module DockerCookbook
 
     # These are helpers for the properties so they are not in an action class
     def default_docker_version
-      '18.03.0'
+      '18.03.1'
     end
 
     def default_package_name
@@ -147,10 +147,19 @@ module DockerCookbook
                    ''
                  end
 
+      # https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20
+      test_versioning_scheme = if Gem::Version.new(v) < Gem::Version.new('17.06.0')
+                   if new_resource.repo_channel == 'stable' && bionic?
+                     '-3'
+                   end
+                 else
+                   ''
+                 end
+
       return "#{v}#{edition}-1.el7.centos" if el7?
       return "#{v}#{edition}" if fedora?
       return "#{v}#{edition}-0~debian#{codename}" if node['platform'] == 'debian'
-      return "#{v}#{edition}-0~ubuntu#{codename}" if node['platform'] == 'ubuntu'
+      return "#{v}#{edition}#{test_versioning_scheme}-0~ubuntu#{codename}" if node['platform'] == 'ubuntu'
       v
     end
   end

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -149,7 +149,7 @@ module DockerCookbook
 
       # https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20
       test_versioning_scheme = if bionic?
-                                 '-3'
+                                 '~3'
                                else
                                  ''
                                end

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -148,13 +148,11 @@ module DockerCookbook
                  end
 
       # https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20
-      test_versioning_scheme = if Gem::Version.new(v) < Gem::Version.new('17.06.0')
-                   if new_resource.repo_channel == 'stable' && bionic?
-                     '-3'
-                   end
-                 else
-                   ''
-                 end
+      test_versioning_scheme = if bionic?
+                                 '-3'
+                               else
+                                 ''
+                               end
 
       return "#{v}#{edition}-1.el7.centos" if el7?
       return "#{v}#{edition}" if fedora?

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -5,7 +5,7 @@ module DockerCookbook
     property :checksum, String, default: lazy { default_checksum }, desired_state: false
     property :source, String, default: lazy { default_source }, desired_state: false
     property :channel, String, default: 'stable', desired_state: false
-    property :version, String, default: '18.03.0', desired_state: false
+    property :version, String, default: '18.03.1', desired_state: false
 
     ##################
     # Property Helpers

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -29,11 +29,13 @@ module DockerCookbook
         case version
         when '17.12.0' then 'dc673421e0368c2c970203350a9d0cb739bc498c897e832779369b0b2a9c6192'
         when '18.03.0' then '2d44ed2ac1e24cb22b6e72cb16d74fc9e60245a8ac1d4f79475604b804f46d38'
+        when '18.03.1' then 'bfb9c599a4fdb45523496c2ead191056ff43d6be90cf0e348421dd56bc3dcf0'
         end
       when 'Linux'
         case version
         when '17.12.0' then '692e1c72937f6214b1038def84463018d8e320c8eaf8530546c84c2f8f9c767d'
         when '18.03.0' then 'e5dff6245172081dbf14285dafe4dede761f8bc1750310156b89928dbf56a9ee'
+        when '18.03.1' then '0e245c42de8a21799ab11179a4fce43b494ce173a8a2d6567ea6825d6c5265aa'
         end
       end
     end

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'docker_test::installation_package' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(platform: 'ubuntu',
+                             version: '18.04',
+                             step_into: ['docker_installation_package']).converge(described_recipe)
+  end
+
+  context 'testing default action, default properties' do
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default').with(version: '18.03.1')
+    end
+  end
+end

--- a/test/cookbooks/docker_test/recipes/installation_package.rb
+++ b/test/cookbooks/docker_test/recipes/installation_package.rb
@@ -1,4 +1,4 @@
 docker_installation_package 'default' do
-  version node['docker']['version']
+  version '18.03.1'
   action :create
 end

--- a/test/integration/installation_package/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_package/inspec/assert_functioning_spec.rb
@@ -5,6 +5,6 @@ if os[:name] == 'amazon'
 else
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/18.03.0/) }
+    its(:stdout) { should match(/18.03.1/) }
   end
 end

--- a/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
@@ -1,5 +1,5 @@
 
 describe command('/usr/bin/docker --version') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/18.03.0/) }
+  its(:stdout) { should match(/18.03.1/) }
 end

--- a/test/integration/resources/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources/inspec/assert_functioning_spec.rb
@@ -9,7 +9,7 @@ uber_options_network_mode = 'bridge'
 # docker_service[default]
 
 describe docker.version do
-  its('Server.Version') { should eq '18.03.0-ce' }
+  its('Server.Version') { should eq '18.03.1-ce' }
 end
 
 describe command('docker info') do


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description

docker-ce has an updated versioning scheme
xenial is ```18.03.1~ce-0~ubuntu```, bionic is ```18.03.1~ce~3-0~ubuntu```
See - https://github.com/docker/docker-ce-packaging/pull/91
See - https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20

Also bump the default version from 18.03.0 to 18.03.1 which is the first official package with bionic support.

### Issues Resolved
This enables ubuntu bionic to be able to install docker-ce
It currently can't find the correct package from the official docker repository

### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
