### PR TITLE
fix for specs ONLY

### DIFF
--- a/spec/docker_test/container_spec.rb
+++ b/spec/docker_test/container_spec.rb
@@ -693,7 +693,7 @@ describe 'docker_test::container' do
         ulimits: [
           'nofile=40960:40960',
           'core=100000000:100000000',
-          'memlock=100000000:100000000'
+          'memlock=100000000:100000000',
         ]
       )
     end
@@ -731,7 +731,7 @@ describe 'docker_test::container' do
         volumes_binds: ['/hostbits:/bits', '/more-hostbits:/more-bits'],
         volumes: { '/root' => {} },
         working_dir: '/',
-        cap_add: %w[NET_ADMIN SYS_RESOURCE],
+        cap_add: %w(NET_ADMIN SYS_RESOURCE),
         cap_drop: ['MKNOD'],
         cpu_shares: 512,
         cpuset_cpus: '0,1',
@@ -747,7 +747,7 @@ describe 'docker_test::container' do
         ulimits: [
           'nofile=40960:40960',
           'core=100000000:100000000',
-          'memlock=100000000:100000000'
+          'memlock=100000000:100000000',
         ],
         labels: { 'foo' => 'bar', 'hello' => 'world' }
       )

--- a/spec/docker_test/container_spec.rb
+++ b/spec/docker_test/container_spec.rb
@@ -27,7 +27,7 @@ describe 'docker_test::container' do
         container_name: 'hello-world',
         repo: 'hello-world',
         tag: 'latest',
-        command: '/hello',
+        command: ['/hello'],
         cgroup_parent: '',
         cpu_shares: 0,
         cpuset_cpus: '',
@@ -51,7 +51,7 @@ describe 'docker_test::container' do
     it 'run docker_container[hello-world]' do
       expect(chef_run).to run_docker_container('busybox_ls').with(
         repo: 'busybox',
-        command: 'ls -la /'
+        command: ['ls', '-la', '/']
       )
     end
 
@@ -59,7 +59,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('alpine_ls').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'ls -la /'
+        command: ['ls', '-la', '/']
       )
     end
   end
@@ -69,7 +69,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('an_echo_server').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ll -p 7 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '7', '-e', '/bin/cat'],
         port: '7:7'
       )
     end
@@ -78,7 +78,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('another_echo_server').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ll -p 7 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '7', '-e', '/bin/cat'],
         port: '7'
       )
     end
@@ -87,7 +87,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('an_udp_echo_server').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ul -p 7 -e /bin/cat',
+        command: ['nc', '-ul', '-p', '7', '-e', '/bin/cat'],
         port: '5007:7/udp'
       )
     end
@@ -96,7 +96,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('multi_ip_port').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ul -p 7 -e /bin/cat',
+        command: ['nc', '-ul', '-p', '7', '-e', '/bin/cat'],
         port: ['8301', '8301:8301/udp', '127.0.0.1:8500:8500', '127.0.1.1:8500:8500']
       )
     end
@@ -105,7 +105,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('port_range').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"',
+        command: ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done'],
         port: ['2000-2001', '2000-2001/udp', '3000-3001/tcp', '7000-7002:8000-8002']
       )
     end
@@ -212,7 +212,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('redeployer').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"',
+        command: ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done'],
         port: '7'
       )
     end
@@ -221,7 +221,7 @@ describe 'docker_test::container' do
       expect(chef_run).to create_docker_container('unstarted_redeployer').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"',
+        command: ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done'],
         port: '7'
       )
     end
@@ -269,7 +269,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[bind_mounter]' do
       expect(chef_run).to run_if_missing_docker_container('bind_mounter').with(
         repo: 'busybox',
-        command: 'ls -la /bits /more-bits',
+        command: ['ls', '-la', '/bits', '/more-bits'],
         volumes_binds: ['/hostbits:/bits', '/more-hostbits:/more-bits', '/winter:/spring:ro'],
         volumes: { '/snow' => {}, '/summer' => {} }
       )
@@ -280,7 +280,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[binds_alias]' do
       expect(chef_run).to run_if_missing_docker_container('binds_alias').with(
         repo: 'busybox',
-        command: 'ls -la /bits /more-bits',
+        command: ['ls', '-la', '/bits', '/more-bits'],
         volumes_binds: ['/fall:/sun', '/winter:/spring:ro'],
         volumes: { '/snow' => {}, '/summer' => {} }
       )
@@ -315,14 +315,14 @@ describe 'docker_test::container' do
 
     it 'create docker_container[chef_container]' do
       expect(chef_run).to create_docker_container('chef_container').with(
-        command: 'true',
+        command: ['true'],
         volumes: { '/opt/chef' => {} }
       )
     end
 
     it 'run_if_missing docker_container[ohai_debian]' do
       expect(chef_run).to run_if_missing_docker_container('ohai_debian').with(
-        command: '/opt/chef/embedded/bin/ohai platform',
+        command: ['/opt/chef/embedded/bin/ohai', 'platform'],
         repo: 'debian',
         volumes_from: ['chef_container']
       )
@@ -334,7 +334,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('env').with(
         repo: 'debian',
         env: ['PATH=/usr/bin', 'FOO=bar'],
-        command: 'env'
+        command: ['env']
       )
     end
   end
@@ -344,7 +344,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('ohai_again').with(
         repo: 'debian',
         volumes_from: ['chef_container'],
-        entrypoint: '/opt/chef/embedded/bin/ohai'
+        entrypoint: ['/opt/chef/embedded/bin/ohai']
       )
     end
 
@@ -352,8 +352,8 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('ohai_again_debian').with(
         repo: 'debian',
         volumes_from: ['chef_container'],
-        entrypoint: '/opt/chef/embedded/bin/ohai',
-        command: 'platform'
+        entrypoint: ['/opt/chef/embedded/bin/ohai'],
+        command: ['platform']
       )
     end
   end
@@ -397,7 +397,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[cap_add_net_admin]' do
       expect(chef_run).to run_if_missing_docker_container('cap_add_net_admin').with(
         repo: 'debian',
-        command: 'bash -c "ip addr add 10.9.8.7/24 brd + dev eth0 label eth0:0 ; ip addr list"',
+        command: ['bash', '-c', 'ip addr add 10.9.8.7/24 brd + dev eth0 label eth0:0 ; ip addr list'],
         cap_add: ['NET_ADMIN']
       )
     end
@@ -405,7 +405,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[cap_add_net_admin_error]' do
       expect(chef_run).to run_if_missing_docker_container('cap_add_net_admin_error').with(
         repo: 'debian',
-        command: 'bash -c "ip addr add 10.9.8.7/24 brd + dev eth0 label eth0:0 ; ip addr list"'
+        command: ['bash', '-c', 'ip addr add 10.9.8.7/24 brd + dev eth0 label eth0:0 ; ip addr list']
       )
     end
   end
@@ -414,7 +414,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[cap_drop_mknod]' do
       expect(chef_run).to run_if_missing_docker_container('cap_drop_mknod').with(
         repo: 'debian',
-        command: 'bash -c "mknod -m 444 /dev/urandom2 c 1 9 ; ls -la /dev/urandom2"',
+        command: ['bash', '-c', 'mknod -m 444 /dev/urandom2 c 1 9 ; ls -la /dev/urandom2'],
         cap_drop: ['MKNOD']
       )
     end
@@ -422,7 +422,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[cap_drop_mknod_error]' do
       expect(chef_run).to run_if_missing_docker_container('cap_drop_mknod_error').with(
         repo: 'debian',
-        command: 'bash -c "mknod -m 444 /dev/urandom2 c 1 9 ; ls -la /dev/urandom2"'
+        command: ['bash', '-c', 'mknod -m 444 /dev/urandom2 c 1 9 ; ls -la /dev/urandom2']
       )
     end
   end
@@ -431,7 +431,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[fqdn]' do
       expect(chef_run).to run_if_missing_docker_container('fqdn').with(
         repo: 'debian',
-        command: 'hostname -f',
+        command: ['hostname', '-f'],
         hostname: 'computers',
         domain_name: 'biz'
       )
@@ -442,7 +442,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[dns]' do
       expect(chef_run).to run_if_missing_docker_container('dns').with(
         repo: 'debian',
-        command: 'cat /etc/resolv.conf',
+        command: ['cat', '/etc/resolv.conf'],
         hostname: 'computers',
         dns: ['4.3.2.1', '1.2.3.4'],
         dns_search: ['computers.biz', 'chef.io']
@@ -454,7 +454,7 @@ describe 'docker_test::container' do
     it 'run_if_missing docker_container[extra_hosts]' do
       expect(chef_run).to run_if_missing_docker_container('extra_hosts').with(
         repo: 'debian',
-        command: 'cat /etc/hosts',
+        command: ['cat', '/etc/hosts'],
         extra_hosts: ['east:4.3.2.1', 'west:1.2.3.4']
       )
     end
@@ -465,7 +465,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('cpu_shares').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'ls -la',
+        command: ['ls', '-la'],
         cpu_shares: 512
       )
     end
@@ -476,7 +476,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('cpuset_cpus').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'ls -la',
+        command: ['ls', '-la'],
         cpuset_cpus: '0,1'
       )
     end
@@ -487,7 +487,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('try_try_again').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'grep asdasdasd /etc/passwd',
+        command: ['grep', 'asdasdasd', '/etc/passwd'],
         restart_policy: 'on-failure',
         restart_maximum_retry_count: 2
       )
@@ -497,7 +497,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('reboot_survivor').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ll -p 123 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '123', '-e', '/bin/cat'],
         port: '123',
         restart_policy: 'always'
       )
@@ -507,7 +507,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('reboot_survivor_retry').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ll -p 123 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '123', '-e', '/bin/cat'],
         port: '123',
         restart_policy: nil,
         restart_maximum_retry_count: 2
@@ -521,7 +521,7 @@ describe 'docker_test::container' do
         repo: 'alpine',
         tag: '3.1',
         env: ['FOO=bar', 'BIZ=baz'],
-        command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"',
+        command: ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done'],
         port: '321'
       )
     end
@@ -531,7 +531,7 @@ describe 'docker_test::container' do
         repo: 'alpine',
         tag: '3.1',
         env: ['FOO=few', 'BIZ=buzz'],
-        command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"',
+        command: ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done'],
         port: '322'
       )
     end
@@ -541,7 +541,7 @@ describe 'docker_test::container' do
         repo: 'alpine',
         tag: '3.1',
         env: ['ASD=asd'],
-        command: 'ping -c 1 hello',
+        command: ['ping', '-c', '1', 'hello'],
         links: ['link_source:hello']
       )
     end
@@ -550,7 +550,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('link_target_2').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'env',
+        command: ['env'],
         links: ['link_source:hello']
       )
     end
@@ -560,7 +560,7 @@ describe 'docker_test::container' do
         repo: 'alpine',
         tag: '3.1',
         env: ['ASD=asd'],
-        command: 'ping -c 1 hello_again',
+        command: ['ping', '-c', '1', 'hello_again'],
         links: ['link_source:hello', 'link_source_2:hello_again']
       )
     end
@@ -569,7 +569,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('link_target_4').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'env',
+        command: ['env'],
         links: ['link_source:hello', 'link_source_2:hello_again']
       )
     end
@@ -584,7 +584,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('another_link_source').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ll -p 456 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '456', '-e', '/bin/cat'],
         port: '456'
       )
     end
@@ -593,7 +593,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('another_link_target').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'ping -c 1 hello',
+        command: ['ping', '-c', '1', 'hello'],
         links: ['another_link_source:derp']
       )
     end
@@ -621,7 +621,7 @@ describe 'docker_test::container' do
 
     it 'creates docker_container[dangler]' do
       expect(chef_run).to create_docker_container('dangler').with(
-        command: 'true'
+        command: ['true']
       )
     end
 
@@ -651,7 +651,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_if_missing_docker_container('mutator').with(
         repo: 'someara/mutator',
         tag: 'latest',
-        command: "sh -c 'touch /mutator-`date +\"%Y-%m-%d_%H-%M-%S\"`'",
+        command: ['sh', '-c', 'touch /mutator-`date +"%Y-%m-%d_%H-%M-%S"`'],
         outfile: '/mutator.tar',
         force: true
       )
@@ -667,7 +667,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('network_mode').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'nc -ll -p 776 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '776', '-e', '/bin/cat'],
         port: '776:776',
         network_mode: 'host'
       )
@@ -687,13 +687,13 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('ulimits').with(
         repo: 'alpine',
         tag: '3.1',
-        command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"',
+        command: ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done'],
         port: '778:778',
         cap_add: ['SYS_RESOURCE'],
         ulimits: [
           'nofile=40960:40960',
           'core=100000000:100000000',
-          'memlock=100000000:100000000',
+          'memlock=100000000:100000000'
         ]
       )
     end
@@ -702,7 +702,7 @@ describe 'docker_test::container' do
   context 'testing api_timeouts' do
     it 'run_if_missing docker_container[api_timeouts]' do
       expect(chef_run).to run_if_missing_docker_container('api_timeouts').with(
-        command: 'nc -ll -p 779 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '779', '-e', '/bin/cat'],
         repo: 'alpine',
         tag: '3.1',
         read_timeout: 60,
@@ -731,7 +731,7 @@ describe 'docker_test::container' do
         volumes_binds: ['/hostbits:/bits', '/more-hostbits:/more-bits'],
         volumes: { '/root' => {} },
         working_dir: '/',
-        cap_add: %w(NET_ADMIN SYS_RESOURCE),
+        cap_add: %w[NET_ADMIN SYS_RESOURCE],
         cap_drop: ['MKNOD'],
         cpu_shares: 512,
         cpuset_cpus: '0,1',
@@ -742,12 +742,12 @@ describe 'docker_test::container' do
         port: '1234:1234',
         volumes_from: ['chef_container'],
         user: 'operator',
-        entrypoint: '/bin/sh -c',
-        command: '"trap exit 0 SIGTERM; while :; do sleep 5; done"',
+        entrypoint: ['/bin/sh', '-c'],
+        command: ['trap exit 0 SIGTERM; while :; do sleep 5; done'],
         ulimits: [
           'nofile=40960:40960',
           'core=100000000:100000000',
-          'memlock=100000000:100000000',
+          'memlock=100000000:100000000'
         ],
         labels: { 'foo' => 'bar', 'hello' => 'world' }
       )
@@ -784,7 +784,7 @@ describe 'docker_test::container' do
       expect(chef_run).to run_docker_container('overrides-2').with(
         repo: 'overrides',
         user: 'operator',
-        command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"',
+        command:  ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done'],
         env: ['FOO=biz'],
         volume: { '/var/log' => {} },
         workdir: '/tmp'
@@ -797,7 +797,7 @@ describe 'docker_test::container' do
       expect(chef_run).to create_docker_container('host_override').with(
         repo: 'alpine',
         host: 'tcp://127.0.0.1:2376',
-        command: 'ls -la /'
+        command: ['ls', '-la', '/']
       )
     end
   end
@@ -805,7 +805,7 @@ describe 'docker_test::container' do
   context 'testing logging drivers' do
     it 'run_if_missing docker_container[syslogger]' do
       expect(chef_run).to run_if_missing_docker_container('syslogger').with(
-        command: 'nc -ll -p 780 -e /bin/cat',
+        command: ['nc', '-ll', '-p', '780', '-e', '/bin/cat'],
         repo: 'alpine',
         tag: '3.1',
         log_driver: 'syslog',

--- a/spec/docker_test/exec_spec.rb
+++ b/spec/docker_test/exec_spec.rb
@@ -10,7 +10,7 @@ describe 'docker_test::exec' do
   it 'run docker_container[busybox_exec]' do
     expect(chef_run).to run_docker_container('busybox_exec').with(
       repo: 'busybox',
-      command: 'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"'
+      command: ['sh', '-c', 'trap exit 0 SIGTERM; while :; do sleep 1; done']
     )
   end
 


### PR DESCRIPTION
commands and entrypoints are interpreted as arrays
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description

fixes all the broken unit tests under the UNIT_AND_LINT=1 section of tests on travis-ci
container commands and entrypoints are interpreted as arrays

### Issues Resolved

unit test changes ONLY

### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
