### PR TITLE
docker_container detach=false

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -554,7 +554,10 @@ module DockerCookbook
       converge_by "starting #{new_resource.container_name}" do
         with_retries do
           current_resource.container.start
-          timeout ? container.wait(timeout) : container.wait unless new_resource.detach
+
+          unless new_resource.detach
+            new_resource.timeout ? current_resource.container.wait(new_resource.timeout) : current_resource.container.wait
+          end
         end
         wait_running_state(true) if new_resource.detach
       end

--- a/spec/docker_test/container_spec.rb
+++ b/spec/docker_test/container_spec.rb
@@ -393,6 +393,35 @@ describe 'docker_test::container' do
     end
   end
 
+  context 'testing detach' do
+    it 'runs docker_container[attached]' do
+      expect(chef_run).to run_docker_container('attached').with(
+        repo: 'debian',
+        volumes_from: ['chef_container'],
+        detach: false
+      )
+    end
+
+    it 'creates file[/marker_container_attached]' do
+      expect(chef_run).to create_file('/marker_container_attached')
+    end
+
+    context 'with timeout' do
+      it 'runs docker_container[attached_with_timeout]' do
+        expect(chef_run).to run_docker_container('attached_with_timeout').with(
+          repo: 'debian',
+          volumes_from: ['chef_container'],
+          detach: false,
+          timeout: 10
+        )
+      end
+
+      it 'creates file[/marker_container_attached_with_timeout]' do
+        expect(chef_run).to create_file('/marker_container_attached_with_timeout')
+      end
+    end
+  end
+
   context 'testing cap_add' do
     it 'run_if_missing docker_container[cap_add_net_admin]' do
       expect(chef_run).to run_if_missing_docker_container('cap_add_net_admin').with(

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -434,6 +434,45 @@ file '/marker_container_sean_was_here' do
 end
 
 #########
+# :detach
+#########
+
+# Inspect volume container with test-kitchen bussers
+docker_container 'attached' do
+  command "touch /opt/chef/attached-#{Time.new.strftime('%Y%m%d%H%M')}"
+  repo 'debian'
+  volumes_from 'chef_container'
+  detach false
+  not_if { ::File.exist?('/marker_container_attached') }
+  action :run
+end
+
+# marker to prevent :run on subsequent converges.
+file '/marker_container_attached' do
+  action :create
+end
+
+######################
+# :detach with timeout
+######################
+
+# Inspect volume container with test-kitchen bussers
+docker_container 'attached_with_timeout' do
+  command "sleep 15 && touch /opt/chef/attached_with_timeout-#{Time.new.strftime('%Y%m%d%H%M')}"
+  repo 'debian'
+  volumes_from 'chef_container'
+  detach false
+  timeout 10
+  not_if { ::File.exist?('/marker_container_attached_with_timeout') }
+  action :run
+end
+
+# marker to prevent :run on subsequent converges.
+file '/marker_container_attached_with_timeout' do
+  action :create
+end
+
+#########
 # cap_add
 #########
 

--- a/test/integration/resources/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources/inspec/assert_functioning_spec.rb
@@ -400,6 +400,28 @@ describe command('docker run --rm --volumes-from chef_container debian ls -la /o
   its(:stdout) { should match(/sean_was_here-/) }
 end
 
+# docker_container[attached]
+describe docker_container('attached') do
+  it { should exist }
+  it { should_not be_running }
+end
+
+describe command('docker run --rm --volumes-from chef_container debian ls -la /opt/chef/') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/attached-\d{12}/) }
+end
+
+# docker_container[attached_with_timeout]
+describe docker_container('attached_with_timeout') do
+  it { should exist }
+  it { should_not be_running }
+end
+
+describe command('docker run --rm --volumes-from chef_container debian ls -la /opt/chef/') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not match(/attached_with_timeout-\d{12}/) }
+end
+
 # docker_container[cap_add_net_admin]
 
 describe docker_container('cap_add_net_admin') do


### PR DESCRIPTION
### Description

A `docker_container` resource with `detach(true)` will fail on Chef 14. The container wait stuff isn't specifying `new_resource` or `current_resource` and gets the following error:

```
    ArgumentError
    -------------
    wrong number of arguments (given 0, expected 1..3)
    
    Cookbook Trace:
    ---------------
    /opt/kitchen/cache/cookbooks/docker/libraries/docker_container.rb:562:in `block (3 levels) in <class:DockerContainer>'
    /opt/kitchen/cache/cookbooks/docker/libraries/docker_base.rb:29:in `with_retries'
    /opt/kitchen/cache/cookbooks/docker/libraries/docker_container.rb:555:in `block (2 levels) in <class:DockerContainer>'
    /opt/kitchen/cache/cookbooks/docker/libraries/docker_container.rb:554:in `block in <class:DockerContainer>'
    /opt/kitchen/cache/cookbooks/docker/libraries/docker_container.rb:716:in `call_action'
    /opt/kitchen/cache/cookbooks/docker/libraries/docker_container.rb:458:in `block in <class:DockerContainer>'
```

This PR has two commits: one adds tests to reproduce this error. The second fixes the `docker_container` resource to not have the error anymore.


### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>

- [x] New functionality includes testing.

- [ ] New functionality has been documented in the README if applicable

    N/A - The detach property was not previously documented so I didn't add it to the README. This isn't actually new functionality anyway, just fixing a bug.

- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
