### PR TITLE
sets the default log_level for the systemd docker service back to nil

### DIFF
--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -47,7 +47,7 @@ module DockerCookbook
     property :ip_masq, [TrueClass, FalseClass]
     property :iptables, [TrueClass, FalseClass]
     property :ipv6, [TrueClass, FalseClass]
-    property :log_level, %w(debug info warn error fatal), default: 'info'
+    property :log_level, %w(debug info warn error fatal)
     property :labels, [String, Array], coerce: proc { |v| coerce_daemon_labels(v) }, desired_state: false
     property :log_driver, %w(json-file syslog journald gelf fluentd awslogs splunk none)
     property :log_opts, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -227,6 +227,6 @@ module DockerCookbook
         return true if o.stdout =~ /CONTAINER/
         false
       end
-    end
+    end unless defined?(DockerCookbook::DockerHelpers::Service)
   end
 end

--- a/spec/docker_test/service_spec.rb
+++ b/spec/docker_test/service_spec.rb
@@ -11,7 +11,7 @@ describe 'docker_test::service' do
   cached(:chef_run) do
     ChefSpec::SoloRunner.new(platform: 'ubuntu',
                              version: '16.04',
-                             step_into: %w[helpers_service docker_service docker_service_base docker_service_manager docker_service_manager_systemd]).converge(described_recipe)
+                             step_into: %w(helpers_service docker_service docker_service_base docker_service_manager docker_service_manager_systemd)).converge(described_recipe)
   end
 
   # If you have to change this file you most likely updated a default service option

--- a/spec/docker_test/service_spec.rb
+++ b/spec/docker_test/service_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+# Require all our libraries
+Dir['libraries/*.rb'].each { |f| require File.expand_path(f) }
+
+describe 'docker_test::service' do
+  before do
+    allow_any_instance_of(DockerCookbook::DockerHelpers::Service).to receive(:installed_docker_version).and_return('18.03.1')
+  end
+
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(platform: 'ubuntu',
+                             version: '16.04',
+                             step_into: %w[helpers_service docker_service docker_service_base docker_service_manager docker_service_manager_systemd]).converge(described_recipe)
+  end
+
+  # If you have to change this file you most likely updated a default service option
+  # Please note that it will require a docker service restart
+  # Which is consumer impacting
+  expected = <<EOH
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target docker.socket firewalld.service
+Requires=docker.socket
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStartPre=/sbin/sysctl -w net.ipv4.ip_forward=1
+ExecStartPre=/sbin/sysctl -w net.ipv6.conf.all.forwarding=1
+ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/16 --group=docker --pidfile=/var/run/docker.pid --storage-driver=overlay2
+ExecStartPost=/usr/lib/docker/docker-wait-ready
+ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Delegate=yes
+KillMode=process
+Restart=always
+StartLimitBurst=3
+StartLimitInterval=60s
+
+
+[Install]
+WantedBy=multi-user.target
+EOH
+
+  it 'creates docker_service[default]' do
+    expect(chef_run).to render_file('/etc/systemd/system/docker.service').with_content { |content|
+      # For tests which run on windows - convert CRLF
+      expect(content.gsub(/[\r\n]+/m, "\n")).to match(expected.gsub(/[\r\n]+/m, "\n"))
+    }
+  end
+end

--- a/spec/docker_test/service_spec.rb
+++ b/spec/docker_test/service_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
-
-# Require all our libraries
-Dir['libraries/*.rb'].each { |f| require File.expand_path(f) }
+require_relative '../../libraries/helpers_service'
 
 describe 'docker_test::service' do
   before do

--- a/test/cookbooks/docker_test/recipes/service.rb
+++ b/test/cookbooks/docker_test/recipes/service.rb
@@ -1,0 +1,7 @@
+
+docker_service 'default' do
+  storage_driver 'overlay2'
+  bip '10.10.10.0/16'
+  service_manager 'systemd'
+  action [:create, :start]
+end


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description
Prevents docker services from restarting when version 4.4.0 is deployed, and other fallout from that change.

docker_service log_level was defaulted from nil to 'info' as part of this PR:
https://github.com/chef-cookbooks/docker/pull/1000/files

The default should not be info, it should default to whatever the docker default is.
Ex. What is defined here if you run the daemon without specifying the option -
https://docs.docker.com/engine/reference/commandline/dockerd/

The net-effect of setting the default from nil to info is that the systemd system unit gets updated 
FROM
ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/16 --group=docker --pidfile=/var/run/docker.pid --storage-driver=overlay2
TO
ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/16 --group=docker --log-level=info --pidfile=/var/run/docker.pid --storage-driver=overlay2

This is not the biggest deal, except that any changes to the systemd unit will cause the docker service to restart.   This is an issue for all consumers of the cookbook.  It will cause the docker service to restart when the defaults change.   

We don't want our docker containers to restart in production when we deploy this cookbook.
I'd probably equate a docker service restart in todays world as the equivalent to a server restart in pre-docker times.  It has a great impact for companies who are 100% dockerized.
We want to be very sensitive to whenever we push out a cookbook which requires any service restart.

This PR reverts the default docker service log_level from 'info' back to nil, and adds chefspec tests for the systemd docker service template.  The chefspec tests will now fail if any of the defaults are changed, which will have the added benefit of meaning that the change will result in a docker service restart.

### Issues Resolved

fix the docker_service default log_level and prevent service restarts caused as a result of consuming 4.4.0 

### Check List

- [ X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
