### PR TITLE
docker_execute -> docker_exec in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,9 +1241,9 @@ docker_container 'file_writer' do
 end
 ```
 
-## docker_execute
+## docker_exec
 
-The `docker_execute` resource allows you to execute commands inside of a running container.
+The `docker_exec` resource allows you to execute commands inside of a running container.
 
 ### Actions
 


### PR DESCRIPTION
The example shows the correct resource name, but the prose says the name is `docker_execute`