### PR TITLE
Implement docker_plugin resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ test/cookbooks/docker_test/
 - [docker_registry](#docker_registry): registry operations
 - [docker_network](#docker_network): network operations
 - [docker_volume](#docker_volume): volume operations
+- [docker_plugin](#docker_plugin): plugin operations
 
 ## Getting Started
 
@@ -1238,6 +1239,40 @@ docker_container 'file_writer' do
   volumes 'hello:/hello'
   command 'touch /hello/sean_was_here'
   action :run_if_missing
+end
+```
+
+## docker_plugin
+
+The `docker_plugin` resource allows you to install, configure, enable, disable and remove [Docker Engine managed plugins](https://docs.docker.com/engine/extend/).
+
+### Actions
+
+- `:install` - Install and configure a plugin if it is not already installed
+- `:update` - Re-configure a plugin
+- `:enable` - Enable a plugin (needs to be done after `:install` before it can
+  be used)
+- `:disable` - Disable a plugin (needs to be done before removing a plugin)
+- `:remove` - Remove a disabled plugin
+
+### Properties
+
+- `local_alias` - Local name for the plugin (defaults to the resource name).
+- `remote` - Ref of the plugin (e.g. `vieux/sshfs`). Defaults to `local_alias` or the resource name. Only used for `:install`.
+- `remote_tag` - Remote tag of the plugin to pull (e.g. `1.0.1`, defaults to `latest`) Only used for `:install`.
+- `options` - Hash of options to set on the plugin. Only used for `:update` and `:install`.
+- `grant_privileges` - Array of privileges or true. If it is true, all privileges requested by the plugin will be automatically granted (potentially dangerous). Otherwise, this must be an array in the same format as returned by the [`/plugins/privileges` docker API](https://docs.docker.com/engine/api/v1.37/#operation/GetPluginPrivileges) endpoint. If the array of privileges is not sufficient for the plugin, docker will reject it and the installation will fail. Defaults to `[]` (empty array => no privileges). Only used for `:install`. Does not modify the privileges of already-installed plugins.
+
+### Examples
+
+```ruby
+docker_plugin 'rbd' do
+  remote 'wetopi/rbd'
+  remote_tag '1.0.1'
+  grant_privileges true
+  options(
+    'RBD_CONF_POOL' => 'docker_volumes'
+  )
 end
 ```
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -132,6 +132,7 @@ suites:
   - recipe[docker_test::image]
   - recipe[docker_test::container]
   - recipe[docker_test::exec]
+  - recipe[docker_test::plugin]
 
 - name: network
   includes: [

--- a/libraries/docker_plugin.rb
+++ b/libraries/docker_plugin.rb
@@ -1,0 +1,125 @@
+module DockerCookbook
+  class DockerPlugin < DockerBase
+    resource_name :docker_plugin
+
+    property :local_alias, String, name_property: true
+    property :remote_tag, String, default: 'latest'
+    property :remote, [String, nil], default: nil
+    property :grant_privileges, [Array, TrueClass], default: []
+    property :options, Hash, default: {}
+
+    default_action :install
+
+    action :install do
+      return if plugin_exists?(local_name)
+      converge_by "Install plugin #{plugin_identifier} as #{local_name}" do
+        install_plugin
+        configure_plugin
+      end
+    end
+
+    action :enable do
+      converge_by "Enable plugin #{local_name}" do
+        enable_plugin
+      end unless plugin_enabled?(local_name)
+    end
+
+    action :disable do
+      converge_by "Disable plugin #{local_name}" do
+        disable_plugin
+      end if plugin_enabled?(local_name)
+    end
+
+    action :update do
+      converge_by "Configure plugin #{local_name}" do
+        configure_plugin
+      end
+    end
+
+    action :remove do
+      converge_by "Remove plugin #{local_name}" do
+        remove_plugin
+      end
+    end
+
+    declare_action_class.class_eval do
+      def remote_name
+        return new_resource.remote unless new_resource.remote.nil? || new_resource.remote.empty?
+        new_resource.local_alias
+      end
+
+      def plugin_identifier
+        "#{remote_name}:#{new_resource.remote_tag}"
+      end
+
+      def local_name
+        new_resource.local_alias
+      end
+
+      def plugin_exists?(name)
+        Docker.connection.get("/plugins/#{name}/json")
+        true
+      rescue Docker::Error::NotFoundError
+        false
+      end
+
+      def plugin_enabled?(name)
+        JSON.parse(Docker.connection.get("/plugins/#{name}/json"))['Enabled']
+      end
+
+      def install_plugin
+        privileges = \
+          if new_resource.grant_privileges == true
+            # user gave a blanket statement about privileges; fetch required privileges from Docker
+            # we pass the identifier as both :name and :remote to accomodate different API versions
+            JSON.parse Docker.connection.get('/plugins/privileges',
+                                             name: plugin_identifier,
+                                             remote: plugin_identifier)
+          else
+            # user gave a specific list of privileges
+            new_resource.grant_privileges
+          end
+
+        # actually do the plugin install
+        body = ''
+
+        opts = { remote: plugin_identifier, name: local_name }
+        Chef::Log.info("pulling plugin #{opts} with privileges #{privileges}")
+        Docker.connection.post('/plugins/pull', opts,
+                               body: JSON.generate(privileges),
+                               response_block: response_block(body))
+
+        last_line = body.split("\n").select { |item| !item.empty? }.last
+        info = JSON.parse last_line
+        raise info['error'] if info.key?('error')
+      end
+
+      def response_block(body)
+        lambda do |chunk, _remaining, _total|
+          body << chunk
+        end
+      end
+
+      def configure_plugin
+        options_for_json = []
+        new_resource.options.each_pair do |k, v|
+          options_for_json.push("#{k}=#{v}")
+        end
+
+        Docker.connection.post("/plugins/#{local_name}/set", {}, body: JSON.generate(options_for_json))
+      end
+
+      def enable_plugin
+        Docker.connection.post("/plugins/#{local_name}/enable", timeout: new_resource.read_timeout)
+      end
+
+      def disable_plugin
+        Docker.connection.post("/plugins/#{local_name}/disable", timeout: new_resource.read_timeout)
+      end
+
+      def remove_plugin
+        Docker.connection.delete("/plugins/#{local_name}")
+      end
+    end
+  end
+end

--- a/spec/docker_test/plugin_spec.rb
+++ b/spec/docker_test/plugin_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+describe 'docker_test::plugin' do
+  cached(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+
+  let(:sshfs_caps) do
+    [
+      {
+        'Name' => 'network',
+        'Value' => ['host'],
+      },
+      {
+        'Name' => 'mount',
+        'Value' => ['/var/lib/docker/plugins/'],
+      },
+      {
+        'Name' => 'mount',
+        'Value' => [''],
+      },
+      {
+        'Name' => 'device',
+        'Value' => ['/dev/fuse'],
+      },
+      {
+        'Name' => 'capabilities',
+        'Value' => ['CAP_SYS_ADMIN'],
+      },
+    ]
+  end
+
+  context 'testing default action, default properties, but with privilege grant' do
+    it 'installs vieux/sshfs' do
+      expect(chef_run).to install_docker_plugin('vieux/sshfs').with(
+        api_retries: 3,
+        grant_privileges: sshfs_caps,
+        options: {},
+        remote_tag: 'latest'
+      )
+    end
+  end
+
+  context 'reconfigure existing plugin' do
+    it 'enables debug on vieux/sshfs' do
+      expect(chef_run).to update_docker_plugin('configure vieux/sshfs').with(
+        api_retries: 3,
+        grant_privileges: [],
+        options: {
+          'DEBUG' => '1',
+        },
+        local_alias: 'vieux/sshfs',
+        remote_tag: 'latest'
+      )
+    end
+  end
+
+  context 'testing the remove action' do
+    it 'removes vieux/sshfs' do
+      expect(chef_run).to remove_docker_plugin('remove vieux/sshfs').with(
+        api_retries: 3,
+        grant_privileges: [],
+        options: {},
+        local_alias: 'vieux/sshfs',
+        remote_tag: 'latest'
+      )
+    end
+  end
+
+  context 'testing configure and install at the same time' do
+    it 'installs wetopi/rbd' do
+      expect(chef_run).to install_docker_plugin('rbd').with(
+        remote: 'wetopi/rbd',
+        remote_tag: '1.0.1',
+        grant_privileges: true,
+        options: {
+          'LOG_LEVEL' => '4',
+        }
+      )
+    end
+
+    it 'removes wetopi/rbd again' do
+      expect(chef_run).to remove_docker_plugin('remove rbd').with(
+        local_alias: 'rbd'
+      )
+    end
+  end
+
+  context 'install is idempotent' do
+    it 'installs vieux/sshfs two times' do
+      expect(chef_run).to install_docker_plugin('sshfs 2.1').with(
+        remote: 'vieux/sshfs',
+        local_alias: 'sshfs',
+        remote_tag: '1.0.1',
+        grant_privileges: true
+      )
+
+      expect(chef_run).to install_docker_plugin('sshfs 2.2').with(
+        remote: 'vieux/sshfs',
+        local_alias: 'sshfs',
+        remote_tag: '1.0.1',
+        grant_privileges: true
+      )
+    end
+  end
+
+  context 'test :enable / :disable action' do
+    it 'enables sshfs' do
+      expect(chef_run).to enable_docker_plugin('enable sshfs').with(
+        local_alias: 'sshfs'
+      )
+    end
+
+    it 'disables sshfs' do
+      expect(chef_run).to disable_docker_plugin('disable sshfs').with(
+        local_alias: 'sshfs'
+      )
+    end
+  end
+end

--- a/test/cookbooks/docker_test/recipes/plugin.rb
+++ b/test/cookbooks/docker_test/recipes/plugin.rb
@@ -1,0 +1,94 @@
+######################
+# :install and :update
+######################
+
+sshfs_caps = [
+  {
+    'Name' => 'network',
+    'Value' => ['host'],
+  },
+  {
+    'Name' => 'mount',
+    'Value' => ['/var/lib/docker/plugins/'],
+  },
+  {
+    'Name' => 'mount',
+    'Value' => [''],
+  },
+  {
+    'Name' => 'device',
+    'Value' => ['/dev/fuse'],
+  },
+  {
+    'Name' => 'capabilities',
+    'Value' => ['CAP_SYS_ADMIN'],
+  },
+]
+
+docker_plugin 'vieux/sshfs' do
+  grant_privileges sshfs_caps
+end
+
+docker_plugin 'configure vieux/sshfs' do
+  action :update
+  local_alias 'vieux/sshfs'
+  options(
+    'DEBUG' => '1'
+  )
+end
+
+docker_plugin 'remove vieux/sshfs' do
+  local_alias 'vieux/sshfs'
+  action :remove
+end
+
+#######################
+# :install with options
+#######################
+
+docker_plugin 'rbd' do
+  remote 'wetopi/rbd'
+  remote_tag '1.0.1'
+  grant_privileges true
+  options(
+    'LOG_LEVEL' => '4'
+  )
+end
+
+docker_plugin 'remove rbd' do
+  local_alias 'rbd'
+  action :remove
+end
+
+#######################################
+# :install twice (should be idempotent)
+#######################################
+
+docker_plugin 'sshfs 2.1' do
+  local_alias 'sshfs'
+  remote 'vieux/sshfs'
+  remote_tag '1.0.1'
+  grant_privileges true
+end
+
+docker_plugin 'sshfs 2.2' do
+  local_alias 'sshfs'
+  remote 'vieux/sshfs'
+  remote_tag '1.0.1'
+  grant_privileges true
+end
+
+docker_plugin 'enable sshfs' do
+  local_alias 'sshfs'
+  action :enable
+end
+
+docker_plugin 'disable sshfs' do
+  local_alias 'sshfs'
+  action :disable
+end
+
+docker_plugin 'remove sshfs again' do
+  local_alias 'sshfs'
+  action :remove
+end


### PR DESCRIPTION
### Description

Implement a ``docker_plugin`` resource which is used to manage [Docker Engine managed plugins](https://docs.docker.com/engine/extend/). This includes installation, enabling/disabling, (re-)configuring and removal of plugins.

### Issues Resolved

* Fixes #942 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

### Notes

* Waiting for travis-ci results on the "All tests pass" front :)
* I’m not entirely sure how to test this better. There are some smoke-testy-tests in `plugins.rb` + corresponding spec tests in the test cookbook, but I’m not 100% happy with it yet. I’m open to suggestions on how to improve this. I only found the two plugins listed (many other plugins are available, but not as Docker Engine managed ones), and both depend on external resources (an ssh server or a Ceph cluster), so creating volumes using those plugins doesn’t seem viable.
* As mentioned in #942, docker-api does not support any Plugin-specific stuff, so we’re using the raw connection object to communicate with Docker. This is even less overhead than I had anticipated, so I think it might be ok to leave it at this.

Let me know if anything is needed.