### PR TITLE
Use correct remote tag to fix tests

### DIFF
--- a/spec/docker_test/plugin_spec.rb
+++ b/spec/docker_test/plugin_spec.rb
@@ -88,15 +88,15 @@ describe 'docker_test::plugin' do
     it 'installs vieux/sshfs two times' do
       expect(chef_run).to install_docker_plugin('sshfs 2.1').with(
         remote: 'vieux/sshfs',
+        remote_tag: 'latest',
         local_alias: 'sshfs',
-        remote_tag: '1.0.1',
         grant_privileges: true
       )
 
       expect(chef_run).to install_docker_plugin('sshfs 2.2').with(
         remote: 'vieux/sshfs',
+        remote_tag: 'latest',
         local_alias: 'sshfs',
-        remote_tag: '1.0.1',
         grant_privileges: true
       )
     end

--- a/test/cookbooks/docker_test/recipes/plugin.rb
+++ b/test/cookbooks/docker_test/recipes/plugin.rb
@@ -67,14 +67,14 @@ end
 docker_plugin 'sshfs 2.1' do
   local_alias 'sshfs'
   remote 'vieux/sshfs'
-  remote_tag '1.0.1'
+  remote_tag 'latest'
   grant_privileges true
 end
 
 docker_plugin 'sshfs 2.2' do
   local_alias 'sshfs'
   remote 'vieux/sshfs'
-  remote_tag '1.0.1'
+  remote_tag 'latest'
   grant_privileges true
 end
 


### PR DESCRIPTION
Obvious fix.

### Description

Use the correct tag for the vieux/sshfs plugin in the tests.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [N/A] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

### Notes

* Fixes test breakage due to #1020.