### PR TITLE
Fix passing of driver and opts to Docker::Volume.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,11 +1218,11 @@ The `docker_volume` resource is responsible for managing Docker named volumes.
 
 ### Properties
 
-- `driver`
+- `driver` - Name of the volume driver to use. Only used for `:create`.
 - `host`
-- `opts`
+- `opts` - Options to pass to the volume driver. Only used for `:create`.
 - `volume`
-- `volume_name`
+- `volume_name` - Name of the volume to operate on (defaults to the resource name).
 
 ### Examples
 

--- a/libraries/docker_volume.rb
+++ b/libraries/docker_volume.rb
@@ -4,7 +4,7 @@ module DockerCookbook
 
     property :driver, String, desired_state: false
     property :host, [String, nil], default: lazy { ENV['DOCKER_HOST'] }, desired_state: false
-    property :opts, [String, Array], desired_state: false
+    property :opts, Hash, desired_state: false
     property :volume, Docker::Volume, desired_state: false
     property :volume_name, String, name_property: true
 
@@ -18,7 +18,14 @@ module DockerCookbook
 
     action :create do
       converge_by "creating volume #{new_resource.volume_name}" do
-        Docker::Volume.create(new_resource.volume_name, {}, connection)
+        opts = {}
+        if property_is_set?(:driver)
+          opts['Driver'] = driver
+        end
+        if property_is_set?(:opts)
+          opts['DriverOpts'] = opts
+        end
+        Docker::Volume.create(new_resource.volume_name, opts, connection)
       end if current_resource.nil?
     end
 


### PR DESCRIPTION
### Description

The `driver` and `opts` properties of the `docker_volume` resource were not used at all, despite their existence being documented in the README. This PR fixes this by passing the properties to the `Docker` call and documenting what they do and when they’re used.

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

### Notes

* I haven’t written tests for this. I have no idea how to do this. I could write something like:

   ```ruby
   docker_volume 'foo' do
     driver 'local'
     action :create
   end
   ```

   but that would not test anything useful, since ``local`` is the default on the Docker side of things, so not passing it and passing ``local`` has the same effect. A "good" way to test this would be with a separate volume driver, however, all drivers I know of require provisioning of an external resource (e.g. sshfs or ceph).

   However, I was able to create a ``wetopi/rbd:1.0.1`` based volume with this fix in our own infrastructure.