### PR TITLE
Include setup_docker_repo in docker_service and allow old docker-ce v…

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -128,9 +128,11 @@ module DockerCookbook
                 end
 
       # https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20
-      test_versioning = '3'
+      test_versioning = new_resource.version.to_f > 18.03 ? '3' : '1'
 
-      return "#{v}#{edition}-#{test_versioning}.el7" if el7?
+      centos_extra = new_resource.version.to_f > 18.03 ? '' : '.centos'
+
+      return "#{v}#{edition}-#{test_versioning}.el7#{centos_extra}" if el7?
       return "#{v}#{edition}" if fedora?
       return "#{v}#{edition}~#{test_versioning}-0~debian" if node['platform'] == 'debian'
       return "#{v}#{edition}~#{test_versioning}-0~ubuntu" if node['platform'] == 'ubuntu'

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -128,9 +128,9 @@ module DockerCookbook
                 end
 
       # https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20
-      test_versioning = new_resource.version.to_f > 18.03 ? '3' : '1'
+      test_versioning = v.to_f > 18.03 ? '3' : '1'
 
-      centos_extra = new_resource.version.to_f > 18.03 ? '' : '.centos'
+      centos_extra = v.to_f > 18.03 ? '' : '.centos'
 
       return "#{v}#{edition}-#{test_versioning}.el7#{centos_extra}" if el7?
       return "#{v}#{edition}" if fedora?

--- a/libraries/docker_service.rb
+++ b/libraries/docker_service.rb
@@ -23,6 +23,7 @@ module DockerCookbook
     # docker_installation_package
     property :package_version, String, desired_state: false
     property :package_name, String, desired_state: false
+    property :setup_docker_repo, [TrueClass, FalseClass], desired_state: false
 
     # package and tarball
     property :version, String, desired_state: false


### PR DESCRIPTION
…ersions for centos

Signed-off-by: Alex Harder <Alex.Harder@Cerner.com>

### Description

Includes setup_docker_repo within docker_service
Allows older docker-ce versions to be used for centos

### Issues Resolved

Fixes #1014 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
