### PR TITLE
Use different version string on .deb packages

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -134,8 +134,10 @@ module DockerCookbook
 
       return "#{v}#{edition}-#{test_versioning}.el7#{centos_extra}" if el7?
       return "#{v}#{edition}" if fedora?
-      return "#{v}#{edition}~#{test_versioning}-0~debian" if node['platform'] == 'debian'
-      return "#{v}#{edition}~#{test_versioning}-0~ubuntu" if node['platform'] == 'ubuntu'
+      return "#{v}#{edition}~#{test_versioning}-0~debian" if node['platform'] == 'debian' && v.to_f > 18.03
+      return "#{v}#{edition}~#{test_versioning}-0~ubuntu" if node['platform'] == 'ubuntu' && v.to_f > 18.03
+      return "#{v}#{edition}-0~debian" if node['platform'] == 'debian'
+      return "#{v}#{edition}-0~ubuntu" if node['platform'] == 'ubuntu'
       v
     end
   end


### PR DESCRIPTION
### Description

After the new debian package version generation, the ubuntu and debian
packages in repositories follow the new convention after docker version
18.03.

This commit adds two more return cases in the package installation
method that computes the version to consider the new naming convention
in docker packages.
### Issues Resolved

This is basically fixes the new naming for packages for debian and ubuntu platforms, as #1024 did for centos.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
