### PR TITLE
Added default-ip-address-pool daemon option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the docker cookbook.
 
+## 4.6.6 (unreleased)
+
+- :default_ip_address_pool property added to configure default address pool for networks created by Docker.
+
 ## 4.6.5 (2018-09-04)
 
 - package names changed again. looks like they swapped xenial and bionic name schema.

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ The `docker_service` resource property list mostly corresponds to the options fo
 - `daemon` - Enable daemon mode
 - `data_root` - Root of the Docker runtime
 - `debug` - Enable debug mode
+- `default_ip_address_pool` - Set the default address pool for networks creates by docker
 - `default_ulimit` - Set default ulimit settings for containers
 - `disable_legacy_registry` - Do not contact legacy registries
 - `dns_search` - DNS search domains to use

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -47,6 +47,7 @@ module DockerCookbook
     property :ip_masq, [TrueClass, FalseClass]
     property :iptables, [TrueClass, FalseClass]
     property :ipv6, [TrueClass, FalseClass]
+    property :default_ip_address_pool, String
     property :log_level, %w(debug info warn error fatal)
     property :labels, [String, Array], coerce: proc { |v| coerce_daemon_labels(v) }, desired_state: false
     property :log_driver, %w(json-file syslog journald gelf fluentd awslogs splunk none)

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -192,6 +192,7 @@ module DockerCookbook
         opts << "--fixed-cidr-v6=#{fixed_cidr_v6}" if fixed_cidr_v6
         opts << "--group=#{group}" if group
         opts << "--data-root=#{data_root}" if data_root
+        opts << "--default-address-pool=#{default_ip_address_pool}" unless default_ip_address_pool.nil?
         host.each { |h| opts << "--host #{h}" } if host
         opts << "--icc=#{icc}" unless icc.nil?
         insecure_registry.each { |i| opts << "--insecure-registry=#{i}" } if insecure_registry

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Provides docker_service, docker_image, and docker_container resources'
-version '4.6.5'
+version '4.6.6'
 
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'

--- a/spec/docker_test/service_spec.rb
+++ b/spec/docker_test/service_spec.rb
@@ -27,7 +27,7 @@ Wants=network-online.target
 Type=notify
 ExecStartPre=/sbin/sysctl -w net.ipv4.ip_forward=1
 ExecStartPre=/sbin/sysctl -w net.ipv6.conf.all.forwarding=1
-ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/16 --group=docker --pidfile=/var/run/docker.pid --storage-driver=overlay2
+ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/24 --group=docker --default-address-pool=base=10.10.10.0/16,size=24 --pidfile=/var/run/docker.pid --storage-driver=overlay2
 ExecStartPost=/usr/lib/docker/docker-wait-ready
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576

--- a/test/cookbooks/docker_test/recipes/service.rb
+++ b/test/cookbooks/docker_test/recipes/service.rb
@@ -1,7 +1,8 @@
 
 docker_service 'default' do
   storage_driver 'overlay2'
-  bip '10.10.10.0/16'
+  bip '10.10.10.0/24'
+  default_ip_address_pool 'base=10.10.10.0/16,size=24'
   service_manager 'systemd'
   action [:create, :start]
 end


### PR DESCRIPTION
### Description

Added support for the new `default-ip-address-pool` daemon parameter.

### Issues Resolved

-

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
