### PR TITLE
Import docker repository gpg key from http

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -31,7 +31,7 @@ module DockerCookbook
             uri "https://download.docker.com/linux/#{node['platform']}"
             arch 'amd64'
             keyserver 'keyserver.ubuntu.com'
-            key '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+            key "https://download.docker.com/linux/#{node['platform']}/gpg"
             action :add
           end
         else


### PR DESCRIPTION
### Description

When installing docker via package on debian platforms, fetch via httsp the latest gpg public key server from download.docker.com

### Issues Resolved

Help avoiding keyserver unavailability transient errors, that is one of the most common transient network errors during first converge.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
