### PR TITLE
add missing object to reload

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -613,7 +613,7 @@ module DockerCookbook
 
     action :reload do
       converge_by "reloading #{new_resource.container_name}" do
-        with_retries { container.kill(signal: 'SIGHUP') }
+        with_retries { current_resource.container.kill(signal: 'SIGHUP') }
       end
     end
 


### PR DESCRIPTION
### Description

Fixes ```NameError: undefined local variable or method `container' for #<#<Class:0x00000000058b9c50>:0x0000000005686b18>``` when attempting to reload a container. 

### Issues Resolved

n/a

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>

[n/a] New functionality includes testing.
[n/a] New functionality has been documented in the README if applicable
[n/a] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
