### PR TITLE
18.09 - add epoch to version string

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -158,8 +158,8 @@ module DockerCookbook
         return "#{v}~ce-0~debian" if debian?
         return "#{v}~ce-0~ubuntu" if ubuntu?
       elsif v.to_f >= 18.09 && debuntu?
-        return "#{v}~ce~#{test_version}-0~debian-#{codename}" if debian?
-        return "#{v}~ce~#{test_version}-0~ubuntu-#{codename}" if ubuntu?
+        return "5:#{v}~#{test_version}-0~debian-#{codename}" if debian?
+        return "5:#{v}~#{test_version}-0~ubuntu-#{codename}" if ubuntu?
       elsif v.to_f >= 18.09 && el7?
         return "#{v}-#{test_version}.el7"
       else

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -31,7 +31,7 @@ describe 'docker_test::installation_package' do
       { docker_version: '18.03.1', expected: '18.03.1~ce~3-0~ubuntu' },
       { docker_version: '18.06.0', expected: '18.06.0~ce~3-0~ubuntu' },
       { docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
-      { docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-bionic' }
+      { docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-bionic' },
     ].each do |suite|
       it 'generates the correct version string ubuntu bionic' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -63,7 +63,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.03.1', expected: '18.03.1~ce-0~ubuntu' },
       {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~ubuntu' },
       {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
-      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-xenial' }
+      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-xenial' },
     ].each do |suite|
       it 'generates the correct version string ubuntu xenial' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -94,7 +94,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.03.1', expected: '18.03.1~ce-0~debian' },
       {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~debian' },
       {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~debian' },
-      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~debian-stretch' }
+      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~debian-stretch' },
     ].each do |suite|
 
       it 'generates the correct version string debian stretch' do

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -31,7 +31,7 @@ describe 'docker_test::installation_package' do
       { docker_version: '18.03.1', expected: '18.03.1~ce~3-0~ubuntu' },
       { docker_version: '18.06.0', expected: '18.06.0~ce~3-0~ubuntu' },
       { docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
-      { docker_version: '18.09.0', expected: '18.09.0~ce~3-0~ubuntu-bionic' }
+      { docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-bionic' }
     ].each do |suite|
       it 'generates the correct version string ubuntu bionic' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -63,7 +63,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.03.1', expected: '18.03.1~ce-0~ubuntu' },
       {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~ubuntu' },
       {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
-      {  docker_version: '18.09.0', expected: '18.09.0~ce~3-0~ubuntu-xenial' }
+      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-xenial' }
     ].each do |suite|
       it 'generates the correct version string ubuntu xenial' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -94,7 +94,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.03.1', expected: '18.03.1~ce-0~debian' },
       {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~debian' },
       {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~debian' },
-      {  docker_version: '18.09.0', expected: '18.09.0~ce~3-0~debian-stretch' }
+      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~debian-stretch' }
     ].each do |suite|
 
       it 'generates the correct version string debian stretch' do


### PR DESCRIPTION
### Description

Did not realize that the epoch is set for 18.09 and required for installation to work properly.
The package can't be installed without specifying the epoch.
See docker-ce 18.09 in
https://download.docker.com/linux/ubuntu/dists/bionic/stable/binary-amd64/Packages
```
Package: docker-ce
Architecture: amd64
Version: 5:18.09.0~3-0~ubuntu-bionic
```

### Issues Resolved

Fixes https://github.com/chef-cookbooks/docker/pull/1040

### Check List

- [ X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
