### PR TITLE
fix issues with network_mode

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -423,11 +423,11 @@ module DockerCookbook
       ro_rootfs container.info['HostConfig']['ReadonlyRootfs']
       if container.info['NetworkSettings'] &&
          container.info['NetworkSettings']['Networks'] &&
-         container.info['NetworkSettings']['Networks'][new_resource.network_mode] &&
-         container.info['NetworkSettings']['Networks'][new_resource.network_mode]['IPAMConfig'] &&
-         container.info['NetworkSettings']['Networks'][new_resource.network_mode]['IPAMConfig']['IPv4Address']
+         container.info['NetworkSettings']['Networks'][network_mode] &&
+         container.info['NetworkSettings']['Networks'][network_mode]['IPAMConfig'] &&
+         container.info['NetworkSettings']['Networks'][network_mode]['IPAMConfig']['IPv4Address']
 
-        ip_address container.info['NetworkSettings']['Networks'][new_resource.network_mode]['IPAMConfig']['IPv4Address']
+        ip_address container.info['NetworkSettings']['Networks'][network_mode]['IPAMConfig']['IPv4Address']
       end
     end
 
@@ -691,15 +691,15 @@ module DockerCookbook
 
         if new_resource.network_mode == 'container' &&
            (
-            !(new_reosurce.hostname.nil? || new_reosurce.hostname.empty?) ||
-            !(new_reosurce.dns.nil? || new_reosurce.dns.empty?) ||
-            !(new_reosurce.dns_search.nil? || new_reosurce.dns_search.empty?) ||
-            !(new_reosurce.mac_address.nil? || new_reosurce.mac_address.empty?) ||
-            !(new_reosurce.extra_hosts.nil? || new_reosurce.extra_hosts.empty?) ||
-            !(new_reosurce.exposed_ports.nil? || new_reosurce.exposed_ports.empty?) ||
-            !(new_reosurce.port_bindings.nil? || new_reosurce.port_bindings.empty?) ||
-            !(new_reosurce.publish_all_ports.nil? || new_reosurce.publish_all_ports.empty?) ||
-            !new_reosurce.port.nil?
+           !(new_resource.hostname.nil? || new_resource.hostname.empty?) ||
+             !(new_resource.dns.nil? || new_resource.dns.empty?) ||
+             !(new_resource.dns_search.nil? || new_resource.dns_search.empty?) ||
+             !(new_resource.mac_address.nil? || new_resource.mac_address.empty?) ||
+             !(new_resource.extra_hosts.nil? || new_resource.extra_hosts.empty?) ||
+             !(new_resource.exposed_ports.nil? || new_resource.exposed_ports.empty?) ||
+             !(new_resource.port_bindings.nil? || new_resource.port_bindings.empty?) ||
+             !(new_resource.publish_all_ports.nil? || new_resource.publish_all_ports.empty?) ||
+             !new_resource.port.nil?
            )
           raise Chef::Exceptions::ValidationFailed, 'Cannot specify hostname, dns, dns_search, mac_address, extra_hosts, exposed_ports, port_bindings, publish_all_ports, port when network_mode is container.'
         end

--- a/spec/libraries/container_spec.rb
+++ b/spec/libraries/container_spec.rb
@@ -1,0 +1,55 @@
+# Load all the libraries
+require 'chef'
+require 'docker'
+Dir['libraries/*.rb'].each { |f| require File.expand_path(f) }
+
+describe DockerCookbook::DockerContainer do
+  let(:resource) { DockerCookbook::DockerContainer.new('hello_world') }
+
+  it 'has a default action of [:run]' do
+    expect(resource.action).to eql([:run])
+  end
+
+  describe 'gets ip_address_from_container_networks' do
+    let(:options) { { 'id' => rand(10_000).to_s } }
+    subject do
+      Docker::Container.send(:new, Docker.connection, options)
+    end
+    # https://docs.docker.com/engine/api/version-history/#v121-api-changes
+    context 'when docker API < 1.21' do
+      let(:ip_address) { '10.0.0.1' }
+      let(:options) do
+        {
+          'id' => rand(10_000).to_s,
+          'IPAddress' => ip_address
+        }
+      end
+      it 'gets ip_address as nil' do
+        actual = resource.ip_address_from_container_networks(subject)
+        expect { resource.ip_address_from_container_networks(subject) }.not_to raise_error
+        expect(actual).to eq(nil)
+      end
+    end
+    context 'when docker API > 1.21' do
+      let(:ip_address) { '10.0.0.1' }
+      let(:options) do
+        {
+          'id' => rand(10_000).to_s,
+          'NetworkSettings' => {
+            'Networks' => {
+              'bridge' => {
+                'IPAMConfig' => {
+                  'IPv4Address' => ip_address
+                }
+              }
+            }
+          }
+        }
+      end
+      it 'gets ip_address' do
+        actual = resource.ip_address_from_container_networks(subject)
+        expect(actual).to eq(ip_address)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

Fix broken issues with existing network_mode implementation which will allow it to be functional.  
Should not break any existing functionality as this is not even called with the existing schema/api version of the docker api gem.
This only gets called when API is 1.21 or greater.  Unless you are overriding the api schema version or using a pre-release version of the docker-api gem this should have no impact.
(There is a blurb about this in the issue.)

It will be good to fix this now as they are preparing version 2.X of the docker api gem.
See - https://github.com/swipely/docker-api/tree/release-2.x
Once this 2.X gem is released and used, this cookbook may break without this change.

### Issues Resolved

https://github.com/chef-cookbooks/docker/issues/998

### Check List

- [ X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
