### PR TITLE
Add support for container health_check options

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `env_file` - Read environment variables from a file and set in the container. Accepts an Array or String to the file location. lazy evaluator must be set if the file passed is created by Chef.
 - `extra_hosts` - An array of hosts to add to the container's `/etc/hosts` in the form `['host_a:10.9.8.7', 'host_b:10.9.8.6']`
 - `force` - A boolean to use in container operations that support a `force` option. Defaults to `false`
+- `health_check` - A hash containing the health check options - https://docs.docker.com/engine/reference/run/#healthcheck
 - `host` - A string containing the host the API should communicate with. Defaults to ENV['DOCKER_HOST'] if set
 - `host_name` - The hostname for the container.
 - `labels` A string, array, or hash to set metadata on the container in the form ['foo:bar', 'hello:world']`
@@ -1087,6 +1088,26 @@ docker_container 'external_daemon' do
   repo 'alpine'
   host 'tcp://1.2.3.4:2376'
   action :create
+end
+```
+
+- Run a container with health_check options
+
+```ruby
+docker_container 'health_check' do
+  repo 'alpine'
+  tag '3.1'
+  health_check ({
+    "Test" =>
+      [
+        "string"
+      ],
+      "Interval" => 0,
+      "Timeout" => 0,
+      "Retries" => 0,
+      "StartPeriod" => 0
+  })
+  action :run
 end
 ```
 

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -26,6 +26,7 @@ module DockerCookbook
     property :extra_hosts, [Array, nil], coerce: proc { |v| Array(v).empty? ? nil : Array(v) }
     property :exposed_ports, PartialHashType, default: {}
     property :force, [TrueClass, FalseClass], default: false, desired_state: false
+    property :health_check, Hash, default: {}
     property :host, [String, nil], default: lazy { ENV['DOCKER_HOST'] }, desired_state: false
     property :hostname, String
     property :ipc_mode, String, default: ''
@@ -542,6 +543,10 @@ module DockerCookbook
             },
           } if new_resource.network_mode
           config.merge! net_config
+
+          config.merge(
+            'Healthcheck' => new_resource.health_check,
+          ) unless new_resource.health_check.empty?
 
           Docker::Container.create(config, connection)
         end

--- a/spec/docker_test/container_spec.rb
+++ b/spec/docker_test/container_spec.rb
@@ -903,4 +903,23 @@ describe 'docker_test::container' do
       )
     end
   end
+
+  context 'testing health_check options' do
+    it 'sets health_check options' do
+      expect(chef_run).to run_docker_container('health_check').with(
+        repo: 'alpine',
+        tag: '3.1',
+        health_check: {
+          "Test" =>
+            [
+              "string"
+            ],
+          "Interval" => 0,
+          "Timeout" => 0,
+          "Retries" => 0,
+          "StartPeriod" => 0
+        }
+      )
+    end
+  end
 end

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -1215,3 +1215,23 @@ docker_container 'memory' do
   memory_reservation '5m'
   action :run
 end
+
+################
+# health_check
+################
+
+docker_container 'health_check' do
+  repo 'alpine'
+  tag '3.1'
+  health_check ({
+    "Test" =>
+      [
+        "string"
+      ],
+      "Interval" => 0,
+      "Timeout" => 0,
+      "Retries" => 0,
+      "StartPeriod" => 0
+  })
+  action :run
+end


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description

Allows health_check to be used for containers
https://docs.docker.com/engine/reference/run/#healthcheck
https://docs.docker.com/engine/api/v1.39/#operation/ContainerCreate

### Issues Resolved

https://github.com/chef-cookbooks/docker/issues/974

### Check List

- [ X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable
- [ X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
