### PR TITLE
docker_registry resource should have 'host' property

### DIFF
--- a/libraries/docker_registry.rb
+++ b/libraries/docker_registry.rb
@@ -12,6 +12,8 @@ module DockerCookbook
 
     property :username, String
 
+    property :host, [String, nil], default: lazy { ENV['DOCKER_HOST'] }, desired_state: false
+
     action :login do
       tries = new_resource.api_retries
 

--- a/spec/libraries/registry_spec.rb
+++ b/spec/libraries/registry_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+require_relative '../../libraries/docker_base'
+require_relative '../../libraries/docker_registry'
+
+describe 'docker_registry' do
+  step_into :docker_registry
+  platform 'ubuntu'
+
+  # Info returned by docker api
+  # https://docs.docker.com/engine/api/v1.39/#section/Authentication
+  let(:auth) do
+    {
+      'identitytoken' => '9cbafc023786cd7...'
+    }.to_json
+  end
+
+  before do
+    # Ensure docker api calls are mocked
+    # It is low level much easier to do in Excon
+    # Plus, the low level mock allows testing this cookbook
+    # for multiple docker apis and docker-api gems
+    # https://github.com/excon/excon#stubs
+    Excon.defaults[:mock] = true
+    Excon.stub({ method: :post, path: '/v1.16/auth' }, body: auth, status: 200)
+  end
+
+  context 'logs into a docker registry with default options' do
+    recipe do
+      docker_registry 'chefspec_custom_registry' do
+        email 'chefspec_email'
+        password 'chefspec_password'
+        username 'chefspec_username'
+      end
+    end
+    it {
+      expect { chef_run }.to_not raise_error
+      expect(chef_run).to login_docker_registry('chefspec_custom_registry').with(
+        email: 'chefspec_email',
+        password: 'chefspec_password',
+        username: 'chefspec_username',
+        host: nil
+      )
+    }
+  end
+
+  context 'logs into a docker registry with host' do
+    recipe do
+      docker_registry 'chefspec_custom_registry' do
+        email 'chefspec_email'
+        password 'chefspec_password'
+        username 'chefspec_username'
+        host 'chefspec_host'
+      end
+    end
+    it {
+      expect { chef_run }.to_not raise_error
+      expect(chef_run).to login_docker_registry('chefspec_custom_registry').with(
+        email: 'chefspec_email',
+        password: 'chefspec_password',
+        username: 'chefspec_username',
+        host: 'chefspec_host'
+      )
+    }
+  end
+
+  context 'logs into a docker registry with host environment variable' do
+    recipe do
+      docker_registry 'chefspec_custom_registry' do
+        email 'chefspec_email'
+        password 'chefspec_password'
+        username 'chefspec_username'
+      end
+    end
+    it {
+      # Set the environment variable
+      stub_const 'ENV', ENV.to_h.merge('DOCKER_HOST' => 'chefspec_host_environment_variable')
+
+      expect { chef_run }.to_not raise_error
+      expect(chef_run).to login_docker_registry('chefspec_custom_registry').with(
+        email: 'chefspec_email',
+        password: 'chefspec_password',
+        username: 'chefspec_username',
+        host: 'chefspec_host_environment_variable'
+      )
+    }
+  end
+end

--- a/spec/libraries/registry_spec.rb
+++ b/spec/libraries/registry_spec.rb
@@ -11,7 +11,7 @@ describe 'docker_registry' do
   # https://docs.docker.com/engine/api/v1.39/#section/Authentication
   let(:auth) do
     {
-      'identitytoken' => '9cbafc023786cd7...'
+      'identitytoken' => '9cbafc023786cd7...',
     }.to_json
   end
 


### PR DESCRIPTION
### Description

Add 'host' property to docker_registry resource

host is required in docker_base
https://github.com/chef-cookbooks/docker/blob/master/libraries/docker_base.rb#L16

host is set in all other providers which inherit from DockerBase
https://github.com/chef-cookbooks/docker/blob/master/libraries/docker_image.rb#L11
https://github.com/chef-cookbooks/docker/blob/master/libraries/docker_network.rb#L11
https://github.com/chef-cookbooks/docker/blob/master/libraries/docker_container.rb#L30
....etc

host is missing from docker_registry - this adds it.  As it initializes a default of `nil` net effect should be no change.

### Issues Resolved


### Check List

- [ X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable
- [ X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
