### PR TITLE
Fix missing reference to new_resource.restart_policy

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -695,7 +695,7 @@ module DockerCookbook
           raise Chef::Exceptions::ValidationFailed, 'restart_policy must be either no, always, unless-stopped, or on-failure.'
         end
 
-        if new_resource.autoremove == true && (new_resource.property_is_set?(:restart_policy) && restart_policy != 'no')
+        if new_resource.autoremove == true && (new_resource.property_is_set?(:restart_policy) && new_resource.restart_policy != 'no')
           raise Chef::Exceptions::ValidationFailed, 'Conflicting options restart_policy and autoremove.'
         end
 


### PR DESCRIPTION
### Description

I was getting a trace back when using the newest version of the cookbook on Chef 14 when trying to set a restart_policy for a container:

```
NameError
    ---------
    undefined local variable or method `restart_policy' for #<#<Class:0x00000000042fe6e0>:0x0000000007337e88>

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/docker/libraries/docker_container.rb:698:in `validate_container_create'
    /var/chef/cache/cookbooks/docker/libraries/docker_container.rb:473:in `block in <class:DockerContainer>'
```

It looks like on line 698 of the docker_container definition, there was a missing new_resource when referencing the restart_policy property of the resource. This causes this property to not work on Chef 14 and higher as new_resource is now required

This pull request adds the missing new_resource reference.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
