### PR TITLE
fix: remove systemd override files

### DIFF
--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -40,21 +40,6 @@ module DockerCookbook
         not_if { docker_name == 'default' && ::File.exist?('/lib/systemd/system/docker.service') }
       end
 
-      # this overrides the main systemd socket
-      template "/etc/systemd/system/#{docker_name}.socket" do
-        source 'systemd/docker.socket-override.erb'
-        cookbook 'docker'
-        owner 'root'
-        group 'root'
-        mode '0644'
-        variables(
-          config: new_resource,
-          docker_name: docker_name,
-          docker_socket: connect_socket
-        )
-        action connect_socket.nil? ? :delete : :create
-      end
-
       # this overrides the main systemd service
       template "/etc/systemd/system/#{docker_name}.service" do
         source 'systemd/docker.service-override.erb'


### PR DESCRIPTION
By providing the override files in `/etc/systemd/system/` it prevents the user from overriding any setting for `docker.service` or `docker.socket`.

The cookbook should just manage the files in `/lib/systemd/system`only.