### PR TITLE
Support setting shared memory size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `running_wait_time` - Amount of seconds `docker_container` wait to determine if a process is running.
 - `runtime` - Runtime to use when running container. Defaults to `runc`.
 - `security_opt` - A list of string values to customize labels for MLS systems, such as SELinux.
+- `shm_size` - The size of `/dev/shm`. The format is `<number><unit>`, where number must be greater than 0. Unit is optional and can be b (bytes), k (kilobytes), m(megabytes), or g (gigabytes). The default is `64m`.
 - `signal` - The signal to send when using the `:kill` action. Defaults to `SIGTERM`.
 - `sysctls` - A hash of sysctls to set on the container. Defaults to `{}`.
 - `tty` - Boolean value to allocate a pseudo-TTY. Defaults to `false`.

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -59,6 +59,7 @@ module DockerCookbook
     property :runtime, String, default: 'runc'
     property :ro_rootfs, [TrueClass, FalseClass], default: false
     property :security_opt, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }
+    property :shm_size, [String, Integer], default: '64m', coerce: proc { |v| coerce_to_bytes(v) }
     property :signal, String, default: 'SIGTERM'
     property :stdin_once, [TrueClass, FalseClass], default: false, desired_state: false
     property :sysctls, Hash, default: {}
@@ -538,6 +539,7 @@ module DockerCookbook
               'ReadonlyRootfs'  => new_resource.ro_rootfs,
               'Runtime'         => new_resource.runtime,
               'SecurityOpt'     => new_resource.security_opt,
+              'ShmSize'         => new_resource.shm_size,
               'Sysctls'         => new_resource.sysctls,
               'Ulimits'         => ulimits_to_hash,
               'UsernsMode'      => new_resource.userns_mode,

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -1213,6 +1213,7 @@ docker_container 'memory' do
   memory_swap '5M'
   memory_swappiness 50
   memory_reservation '5m'
+  shm_size '32m'
   action :run
 end
 

--- a/test/integration/resources/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources/inspec/assert_functioning_spec.rb
@@ -955,3 +955,8 @@ describe command("docker inspect -f '{{ .HostConfig.MemoryReservation }}' memory
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/5242880/) }
 end
+
+describe command("docker inspect -f '{{ .HostConfig.ShmSize }}' memory") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/67108864/) }
+end


### PR DESCRIPTION
### Description
This change enables setting the shared memory size of a container, as one would with `docker run --shm-size ...`.

This functionality was added in Docker 1.10.0 - this would break older Dockers. I do not know what level of compatibility this project attempts to maintain with Docker itself.

### Issues Resolved

#1030 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
