### PR TITLE
Add epoch to version string on RHEL and CentOS

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -175,7 +175,7 @@ module DockerCookbook
         return "5:#{v}~#{test_version}-0~debian-#{codename}" if debian?
         return "5:#{v}~#{test_version}-0~ubuntu-#{codename}" if ubuntu?
       elsif v.to_f >= 18.09 && el7?
-        return "#{v}-#{test_version}.el7"
+        return "3:#{v}-#{test_version}.el7"
       elsif v.to_f >= 18.09 && fedora?
         return v.to_s
       else

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -129,8 +129,8 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.03.1', expected: '18.03.1.ce-1.el7.centos' },
       {  docker_version: '18.06.0', expected: '18.06.0.ce-3.el7' },
       {  docker_version: '18.06.1', expected: '18.06.1.ce-3.el7' },
-      {  docker_version: '18.09.0', expected: '18.09.0-3.el7' },
-      {  docker_version: '19.03.5', expected: '19.03.5-3.el7' },
+      {  docker_version: '18.09.0', expected: '3:18.09.0-3.el7' },
+      {  docker_version: '19.03.5', expected: '3:19.03.5-3.el7' },
     ].each do |suite|
       it 'generates the correct version string centos 7' do
         custom_resource = chef_run.docker_installation_package('default')


### PR DESCRIPTION
### Description

The docker_installation_package resource omits the "3" epoch number on versions >= 18.09 which causes yum's version comparison to get confused and think that a version is older than the installed version even if the primary version number if greater. This means you can't install one version and then upgrade it later. Instead you get a warning like the following:

```
yum_package[docker-ce] action install[2019-09-12T00:00:01+00:00] WARN:
yum_package[docker-ce] docker-ce has installed version 3:18.09.7-3.el7.x86_64,
which is newer than available version 19.03.2-3.el7. Skipping...)
```

Best I can tell, the epoch number is currently static at 3 in the docker-ce RPM spec (see https://github.com/docker/docker-ce-packaging/blob/master/rpm/SPECS/docker-ce.spec) so I've kept the same approach as with Debian/Ubuntu distros.

### Issues Resolved

#1065 (Partly anyway. There may be additional work on Ubuntu. Not much context for that issue)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
