### PR TITLE
Default to version 19.03.5 and update/fix systemd unit

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -54,7 +54,7 @@ module DockerCookbook
 
     # These are helpers for the properties so they are not in an action class
     def default_docker_version
-      '18.06.0'
+      '19.03.5'
     end
 
     def default_package_name

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -5,7 +5,7 @@ module DockerCookbook
     property :checksum, String, default: lazy { default_checksum }, desired_state: false
     property :source, String, default: lazy { default_source }, desired_state: false
     property :channel, String, default: 'stable', desired_state: false
-    property :version, String, default: '18.06.0', desired_state: false
+    property :version, String, default: '19.03.5', desired_state: false
 
     ##################
     # Property Helpers
@@ -31,6 +31,7 @@ module DockerCookbook
         when '18.03.0' then '2d44ed2ac1e24cb22b6e72cb16d74fc9e60245a8ac1d4f79475604b804f46d38'
         when '18.03.1' then 'bbfb9c599a4fdb45523496c2ead191056ff43d6be90cf0e348421dd56bc3dcf0'
         when '18.06.0' then '5489360ae1894375a56255fb821fcf368b33027cd4f4bbaebf5176c05b79f420'
+        when '19.03.5' then 'fd62b9239045a7356c9d36492779b8611dc783f455f5bf66a77b0bd7b2ec3913'
         end
       when 'Linux'
         case version
@@ -38,6 +39,7 @@ module DockerCookbook
         when '18.03.0' then 'e5dff6245172081dbf14285dafe4dede761f8bc1750310156b89928dbf56a9ee'
         when '18.03.1' then '0e245c42de8a21799ab11179a4fce43b494ce173a8a2d6567ea6825d6c5265aa'
         when '18.06.0' then '1c2fa625496465c68b856db0ba850eaad7a16221ca153661ca718de4a2217705'
+        when '19.03.5' then '50cdf38749642ec43d6ac50f4a3f1f7f6ac688e8d8b4e1c5b7be06e1a82f06e9'
         end
       end
     end

--- a/libraries/docker_service_manager_systemd.rb
+++ b/libraries/docker_service_manager_systemd.rb
@@ -26,6 +26,7 @@ module DockerCookbook
       end
 
       # stock systemd unit file
+      # See - https://github.com/docker/docker-ce-packaging/blob/master/systemd/docker.service
       template "/lib/systemd/system/#{docker_name}.service" do
         source 'systemd/docker.service.erb'
         cookbook 'docker'

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -32,6 +32,7 @@ describe 'docker_test::installation_package' do
       { docker_version: '18.06.0', expected: '18.06.0~ce~3-0~ubuntu' },
       { docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
       { docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-bionic' },
+      { docker_version: '19.03.5', expected: '5:19.03.5~3-0~ubuntu-bionic' },
     ].each do |suite|
       it 'generates the correct version string ubuntu bionic' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -64,6 +65,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~ubuntu' },
       {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
       {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-xenial' },
+      {  docker_version: '19.03.5', expected: '5:19.03.5~3-0~ubuntu-xenial' },
     ].each do |suite|
       it 'generates the correct version string ubuntu xenial' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -95,6 +97,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~debian' },
       {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~debian' },
       {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~debian-stretch' },
+      {  docker_version: '19.03.5', expected: '5:19.03.5~3-0~debian-stretch' },
     ].each do |suite|
       it 'generates the correct version string debian stretch' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -127,6 +130,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.06.0', expected: '18.06.0.ce-3.el7' },
       {  docker_version: '18.06.1', expected: '18.06.1.ce-3.el7' },
       {  docker_version: '18.09.0', expected: '18.09.0-3.el7' },
+      {  docker_version: '19.03.5', expected: '19.03.5-3.el7' },
     ].each do |suite|
       it 'generates the correct version string centos 7' do
         custom_resource = chef_run.docker_installation_package('default')

--- a/templates/default/systemd/docker.service.erb
+++ b/templates/default/systemd/docker.service.erb
@@ -1,38 +1,52 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
+BindsTo=containerd.service
 <% if @docker_socket.nil? %>
-After=network-online.target firewalld.service
+After=network-online.target firewalld.service containerd.service
+Wants=network-online.target
 <% else %>
-After=network-online.target <%= @docker_name %>.socket firewalld.service
+After=network-online.target <%= @docker_name %>.socket firewalld.service containerd.service
+Wants=network-online.target
 Requires=<%= @docker_name %>.socket
 <% end %>
-Wants=network-online.target
 
 [Service]
 Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
 ExecReload=/bin/kill -s HUP $MAINPID
-LimitNOFILE=1048576
+TimeoutSec=0
+RestartSec=2
+Restart=always
+
+# Note that StartLimit* options were moved from "Service" to "Unit" in systemd 229.
+# Both the old, and new location are accepted by systemd 229 and up, so using the old location
+# to make them work for either version of systemd.
+StartLimitBurst=3
+
+# Note that StartLimitInterval was renamed to StartLimitIntervalSec in systemd 230.
+# Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
+# this option work for either version of systemd.
+StartLimitInterval=60s
+
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
-# Uncomment TasksMax if your systemd version supports it.
-# Only systemd 226 and above support this version.
+
+# Comment TasksMax if your systemd version does not support it.
+# Only systemd 226 and above support this option.
 TasksMax=infinity
-TimeoutStartSec=0
+
 # set delegate yes so that systemd does not reset the cgroups of docker containers
 Delegate=yes
+
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
-# restart the docker process if it exits prematurely
-Restart=on-failure
-StartLimitBurst=3
-StartLimitInterval=60s
 
 [Install]
 WantedBy=multi-user.target

--- a/test/cookbooks/docker_test/recipes/installation_package.rb
+++ b/test/cookbooks/docker_test/recipes/installation_package.rb
@@ -1,4 +1,4 @@
 docker_installation_package 'default' do
-  version '18.06.0'
+  version '19.03.5'
   action :create
 end

--- a/test/integration/installation_package/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_package/inspec/assert_functioning_spec.rb
@@ -5,6 +5,6 @@ if os[:name] == 'amazon'
 else
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/18.06.0/) }
+    its(:stdout) { should match(/19.03.5/) }
   end
 end

--- a/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
@@ -1,4 +1,4 @@
 describe command('/usr/bin/docker --version') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/18.06.0/) }
+  its(:stdout) { should match(/19.03.5/) }
 end

--- a/test/integration/resources/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources/inspec/assert_functioning_spec.rb
@@ -9,7 +9,7 @@ uber_options_network_mode = 'bridge'
 # docker_service[default]
 
 describe docker.version do
-  its('Server.Version') { should eq '18.06.0-ce' }
+  its('Server.Version') { should eq '19.03.5-ce' }
 end
 
 describe command('docker info') do


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description

- update to the latest version of docker for security reasons.  Should not by default install the pre-CVE-2019-5736 docker version.
- upgrade the systemd unit to more closely align with the docker provided default found at https://github.com/docker/docker-ce-packaging/blob/master/systemd/docker.service
This fixes the issue below where the containerd dependency is broken in newer versions of docker.

### Issues Resolved

https://github.com/chef-cookbooks/docker/issues/1062

### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X ] New functionality includes testing.
- [X ] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
