### PR TITLE
Fix rpm epoch for el7

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -161,7 +161,7 @@ module DockerCookbook
         return "5:#{v}~#{test_version}-0~debian-#{codename}" if debian?
         return "5:#{v}~#{test_version}-0~ubuntu-#{codename}" if ubuntu?
       elsif v.to_f >= 18.09 && el7?
-        return "#{v}-#{test_version}.el7"
+        return "3:#{v}-#{test_version}.el7"
       else
         return "#{v}.ce" if fedora?
         return "#{v}.ce-#{test_version}.el7" if el7?

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -129,8 +129,8 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.03.1', expected: '18.03.1.ce-1.el7.centos' },
       {  docker_version: '18.06.0', expected: '18.06.0.ce-3.el7' },
       {  docker_version: '18.06.1', expected: '18.06.1.ce-3.el7' },
-      {  docker_version: '18.09.0', expected: '18.09.0-3.el7' },
-      {  docker_version: '19.03.5', expected: '19.03.5-3.el7' },
+      {  docker_version: '18.09.0', expected: '3:18.09.0-3.el7' },
+      {  docker_version: '19.03.5', expected: '3:19.03.5-3.el7' },
     ].each do |suite|
       it 'generates the correct version string centos 7' do
         custom_resource = chef_run.docker_installation_package('default')


### PR DESCRIPTION
### Description

It seems that starting with version 18.09, docker-ce rpms have an [epoch of 3](https://github.com/docker/docker-ce-packaging/blob/master/rpm/gen-rpm-ver#L16). The mechanism used for passing the version to the package resource does not account for this, and thus causes issues under Chef Infra Client 15. I'm unsure why this doesn't appear on Chef Infra Client 14.

The specific issue I am observing is that `docker_installation_package` is not idempotent under Chef 15.

```
First chef run should have reached a converged state.
Resources updated in a second chef-client run:
- docker_installation_package[default]
bash: line 6: 13276 Killed                  sh -c '
TEST_KITCHEN="1"; export TEST_KITCHEN
sudo -E /opt/chef/bin/chef-client --local-mode --config /tmp/kitchen/client_no_updated_resources.rb --log_level auto --force-formatter --no-color --json-attributes /tmp/kitchen/dna.json --chef-zero-port 8889
```

I updated two lines in `spec/docker_test/installation_package_spec.rb` to reflect this change. It looks like there are some unrelated failing tests for code that I haven't touched.

Let me know if I missed anything for this PR. Thanks!

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
