### PR TITLE
Include support for other architectures using upstream repo

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -17,19 +17,33 @@ module DockerCookbook
       if new_resource.setup_docker_repo
         if platform_family?('rhel', 'fedora')
           platform = platform?('fedora') ? 'fedora' : 'centos'
+          arch = node['kernel']['machine']
 
           yum_repository 'Docker' do
-            baseurl "https://download.docker.com/linux/#{platform}/#{node['platform_version'].to_i}/x86_64/#{new_resource.repo_channel}"
+            baseurl "https://download.docker.com/linux/#{platform}/#{node['platform_version'].to_i}/#{arch}/#{new_resource.repo_channel}"
             gpgkey "https://download.docker.com/linux/#{platform}/gpg"
             description "Docker #{new_resource.repo_channel.capitalize} repository"
             gpgcheck true
             enabled true
           end
         elsif platform_family?('debian')
+          deb_arch =
+            case node['kernel']['machine']
+            when 'x86_64'
+              'amd64'
+            when 'aarch64'
+              'arm64'
+            when 'armv7l'
+              'armhf'
+            when 'ppc64le'
+              'ppc64el'
+            else
+              node['kernel']['machine']
+            end
           apt_repository 'Docker' do
             components Array(new_resource.repo_channel)
             uri "https://download.docker.com/linux/#{node['platform']}"
-            arch 'amd64'
+            arch deb_arch
             keyserver 'keyserver.ubuntu.com'
             key "https://download.docker.com/linux/#{node['platform']}/gpg"
             action :add


### PR DESCRIPTION
Currently yum and apt both have x86_64/amd64 set statically in their repository
URL's. Upstream currently supports at least aarch64 as well as armv7l on Debian.
I also included ppc64le just in case they add this later and fall back to
``node['kernel']['machine']`` if nothing is found.

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
