### PR TITLE
Verify debian 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
   - INSTANCE=network-ubuntu-1604
   - INSTANCE=volume-ubuntu-1604
   - INSTANCE=resources-debian-9
+  - INSTANCE=resources-debian-10
   - INSTANCE=resources-centos-7
   - INSTANCE=resources-fedora-latest
   - INSTANCE=resources-ubuntu-1604

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This cookbook is concerned with the [Docker](http://docker.io) container engine 
 ## Platform Support
 
 - Amazon Linux
-- Debian 8/9
+- Debian 8/9/10
 - Fedora
 - Ubuntu 14.04/16.04
 - CentOS 7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -37,6 +37,13 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
+- name: debian-10
+  driver:
+    image: dokken/debian-10
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
 - name: centos-7
   driver:
     image: dokken/centos-7

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -107,6 +107,34 @@ describe 'docker_test::installation_package' do
     end
   end
 
+  context 'version strings for Debian 10' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'debian',
+                               version: '10',
+                               step_into: ['docker_installation_package']).converge(described_recipe)
+    end
+    [
+      {  docker_version: '17.12.1', expected: '17.12.1~ce-0~debian' },
+      {  docker_version: '18.03.0', expected: '18.03.0~ce-0~debian' },
+      {  docker_version: '18.03.1', expected: '18.03.1~ce-0~debian' },
+      {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~debian' },
+      {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~debian' },
+      {  docker_version: '18.06.2', expected: '18.06.2~ce~3-0~debian' },
+      {  docker_version: '18.06.3', expected: '18.06.3~ce~3-0~debian' },
+      {  docker_version: '19.03.5', expected: '5:19.03.5~3-0~debian-buster' },
+      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~debian-buster' },
+      {  docker_version: '18.09.9', expected: '5:18.09.9~3-0~debian-buster' },
+      {  docker_version: '19.03.0', expected: '5:19.03.0~3-0~debian-buster' },
+      {  docker_version: '19.03.5', expected: '5:19.03.5~3-0~debian-buster' },
+    ].each do |suite|
+      it 'generates the correct version string debian stretch' do
+        custom_resource = chef_run.docker_installation_package('default')
+        actual = custom_resource.version_string(suite[:docker_version])
+        expect(actual).to eq(suite[:expected])
+      end
+    end
+  end
+
   context 'version strings for Centos 7' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos',


### PR DESCRIPTION
### Description

I've been using this recipe with Debian 10 without any issues. So I've configured the tests to run on debian 10, the same way they do for debian 9, and they all pass.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
