### PR TITLE
Use new_resource to read attribute

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -697,7 +697,7 @@ module DockerCookbook
           raise Chef::Exceptions::ValidationFailed, 'restart_policy must be either no, always, unless-stopped, or on-failure.'
         end
 
-        if new_resource.autoremove == true && (new_resource.property_is_set?(:restart_policy) && restart_policy != 'no')
+        if new_resource.autoremove == true && (new_resource.property_is_set?(:restart_policy) && new_resource.restart_policy != 'no')
           raise Chef::Exceptions::ValidationFailed, 'Conflicting options restart_policy and autoremove.'
         end
 


### PR DESCRIPTION
### Description
This fixes the following error:
```
    NameError
    ---------
    undefined local variable or method `restart_policy' for #<#<Class:0x00000000054923c0>:0x0000000008167a80>

```