### PR TITLE
Require Chef Infra Client 15+ to fix issues with package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ env:
   - INSTANCE=installation-tarball-ubuntu-1804
   - INSTANCE=installation-package-ubuntu-1604
   - INSTANCE=installation-package-ubuntu-1804
-  - INSTANCE=registry-ubuntu-1604
-  - INSTANCE=network-ubuntu-1604
-  - INSTANCE=volume-ubuntu-1604
+  - INSTANCE=registry-ubuntu-1804
+  - INSTANCE=network-ubuntu-1804
+  - INSTANCE=volume-ubuntu-1804
   - INSTANCE=resources-debian-9
   - INSTANCE=resources-debian-10
   - INSTANCE=resources-centos-7

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This cookbook is concerned with the [Docker](http://docker.io) container engine 
 
 ## Requirements
 
-- Chef 13 or later
+- Chef Infra Client 15 or later
 - Network accessible web server hosting the docker binary.
 - SELinux permissive/disabled if CentOS [Docker Issue #15498](https://github.com/docker/docker/issues/15498)
 
@@ -19,7 +19,7 @@ This cookbook is concerned with the [Docker](http://docker.io) container engine 
 - Amazon Linux 2
 - Debian 9/10
 - Fedora
-- Ubuntu 14.04/16.04
+- Ubuntu 16.04/18.04
 - CentOS 7
 
 ## Cookbook Dependencies

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -102,7 +102,7 @@ suites:
 - name: installation_package
   attributes:
     docker:
-      version: '19.03'
+      version: '19.03.8'
   run_list:
   - recipe[docker_test::installation_package]
   excludes: ['amazonlinux-2']
@@ -110,7 +110,7 @@ suites:
 - name: installation_tarball
   attributes:
     docker:
-      version: '19.03'
+      version: '19.03.8'
   run_list:
   - recipe[docker_test::installation_tarball]
   includes: [
@@ -125,7 +125,7 @@ suites:
 - name: resources
   attributes:
     docker:
-      version: '19.03'
+      version: '19.03.8'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::image]
@@ -139,7 +139,7 @@ suites:
    ]
   attributes:
     docker:
-      version: '19.03'
+      version: '19.03.8'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::network]
@@ -150,7 +150,7 @@ suites:
    ]
   attributes:
     docker:
-      version: '19.03'
+      version: '19.03.8'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::volume]
@@ -161,7 +161,7 @@ suites:
    ]
   attributes:
     docker:
-      version: '19.03'
+      version: '19.03.8'
   run_list:
   - recipe[docker_test::default]
   - recipe[docker_test::registry]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -105,6 +105,7 @@ suites:
       version: '19.03'
   run_list:
   - recipe[docker_test::installation_package]
+  excludes: ['amazonlinux-2']
 
 - name: installation_tarball
   attributes:
@@ -134,7 +135,7 @@ suites:
 
 - name: network
   includes: [
-    'ubuntu-16.04',
+    'ubuntu-18.04',
    ]
   attributes:
     docker:
@@ -145,7 +146,7 @@ suites:
 
 - name: volume
   includes: [
-    'ubuntu-16.04',
+    'ubuntu-18.04',
    ]
   attributes:
     docker:
@@ -156,7 +157,7 @@ suites:
 
 - name: registry
   includes: [
-    'ubuntu-16.04',
+    'ubuntu-18.04',
    ]
   attributes:
     docker:

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -9,64 +9,6 @@ module DockerCookbook
     property :version, String, default: '19.03.8', desired_state: false
     property :package_options, String, desired_state: false
 
-    action :create do
-      if new_resource.setup_docker_repo
-        if platform_family?('rhel', 'fedora')
-          platform = platform?('fedora') ? 'fedora' : 'centos'
-          arch = node['kernel']['machine']
-
-          yum_repository 'Docker' do
-            baseurl "https://download.docker.com/linux/#{platform}/#{node['platform_version'].to_i}/#{arch}/#{new_resource.repo_channel}"
-            gpgkey "https://download.docker.com/linux/#{platform}/gpg"
-            description "Docker #{new_resource.repo_channel.capitalize} repository"
-            gpgcheck true
-            enabled true
-          end
-        elsif platform_family?('debian')
-          deb_arch =
-            case node['kernel']['machine']
-            when 'x86_64'
-              'amd64'
-            when 'aarch64'
-              'arm64'
-            when 'armv7l'
-              'armhf'
-            when 'ppc64le'
-              'ppc64el'
-            else
-              node['kernel']['machine']
-            end
-          apt_repository 'Docker' do
-            components Array(new_resource.repo_channel)
-            uri "https://download.docker.com/linux/#{node['platform']}"
-            arch deb_arch
-            keyserver 'keyserver.ubuntu.com'
-            key "https://download.docker.com/linux/#{node['platform']}/gpg"
-            action :add
-          end
-        else
-          Chef::Log.warn("Cannot setup the Docker repo for platform #{node['platform']}. Skipping.")
-        end
-      end
-
-      package new_resource.package_name do
-        version new_resource.package_version
-        options new_resource.package_options
-        action :install
-      end
-    end
-
-    action :delete do
-      package new_resource.package_name do
-        action :remove
-      end
-    end
-
-    # These are helpers for the properties so they are not in an action class
-    def default_docker_version
-      '19.03.5'
-    end
-
     def el7?
       return true if platform_family?('rhel') && node['platform_version'].to_i == 7
       false
@@ -135,22 +77,77 @@ module DockerCookbook
       test_version = '3'
 
       if v.to_f < 18.06 && !bionic?
-        return "#{v}.ce-1.el7.centos" if el7?
         return "#{v}~ce-0~debian" if debian?
         return "#{v}~ce-0~ubuntu" if ubuntu?
       elsif v.to_f >= 18.09 && debuntu?
         return "5:#{v}~#{test_version}-0~debian-#{codename}" if debian?
         return "5:#{v}~#{test_version}-0~ubuntu-#{codename}" if ubuntu?
-      elsif v.to_f >= 18.09 && el7?
-        "#{v}-#{test_version}.el7"
-      elsif v.to_f >= 18.09 && fedora?
-        v.to_s
       else
-        return "#{v}.ce" if fedora?
-        return "#{v}.ce-#{test_version}.el7" if el7?
         return "#{v}~ce~#{test_version}-0~debian" if debian?
         return "#{v}~ce~#{test_version}-0~ubuntu" if ubuntu?
         v
+      end
+    end
+
+    action :create do
+      if new_resource.setup_docker_repo
+        if platform_family?('rhel', 'fedora')
+          platform = platform?('fedora') ? 'fedora' : 'centos'
+          arch = node['kernel']['machine']
+
+          yum_repository 'Docker' do
+            baseurl "https://download.docker.com/linux/#{platform}/#{node['platform_version'].to_i}/#{arch}/#{new_resource.repo_channel}"
+            gpgkey "https://download.docker.com/linux/#{platform}/gpg"
+            description "Docker #{new_resource.repo_channel.capitalize} repository"
+            gpgcheck true
+            enabled true
+          end
+        elsif platform_family?('debian')
+          deb_arch =
+            case node['kernel']['machine']
+            when 'x86_64'
+              'amd64'
+            when 'aarch64'
+              'arm64'
+            when 'armv7l'
+              'armhf'
+            when 'ppc64le'
+              'ppc64el'
+            else
+              node['kernel']['machine']
+            end
+          apt_repository 'Docker' do
+            components Array(new_resource.repo_channel)
+            uri "https://download.docker.com/linux/#{node['platform']}"
+            arch deb_arch
+            key "https://download.docker.com/linux/#{node['platform']}/gpg"
+            action :add
+          end
+        else
+          Chef::Log.warn("Cannot setup the Docker repo for platform #{node['platform']}. Skipping.")
+        end
+      end
+
+      package full_package_name do
+        version new_resource.package_version unless platform_family?('rhel', 'fedora') # rhel / fedora have the version injected in the name
+        options new_resource.package_options
+        action :install
+      end
+    end
+
+    action :delete do
+      package new_resource.package_name do
+        action :remove
+      end
+    end
+
+    action_class do
+      def full_package_name
+        if platform_family?('rhel', 'fedora')
+          new_resource.package_name + "-#{new_resource.version}*"
+        else
+          new_resource.package_name
+        end
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,5 +17,5 @@ supports 'fedora'
 supports 'redhat'
 supports 'ubuntu'
 
-chef_version '>= 13.0'
+chef_version '>= 15.0'
 gem 'docker-api', '~> 1.34.0'

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -119,46 +119,4 @@ describe 'docker_test::installation_package' do
       end
     end
   end
-
-  context 'version strings for Centos 7' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos',
-                               version: '7',
-                               step_into: ['docker_installation_package']).converge(described_recipe)
-    end
-    # https://download.docker.com/linux/centos/7/x86_64/stable/Packages/
-    [
-      {  docker_version: '18.03.0', expected: '18.03.0.ce-1.el7.centos' },
-      {  docker_version: '18.03.1', expected: '18.03.1.ce-1.el7.centos' },
-      {  docker_version: '18.06.0', expected: '18.06.0.ce-3.el7' },
-      {  docker_version: '18.06.1', expected: '18.06.1.ce-3.el7' },
-      {  docker_version: '18.09.0', expected: '18.09.0-3.el7' },
-      {  docker_version: '19.03.5', expected: '19.03.5-3.el7' },
-    ].each do |suite|
-      it 'generates the correct version string centos 7' do
-        custom_resource = chef_run.docker_installation_package('default')
-        actual = custom_resource.version_string(suite[:docker_version])
-        expect(actual).to eq(suite[:expected])
-      end
-    end
-  end
-  context 'version strings for Fedora' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'fedora',
-                               step_into: ['docker_installation_package']).converge(described_recipe)
-    end
-    # https://download.docker.com/linux/fedora/28/x86_64/stable/Packages/
-    [
-        {  docker_version: '18.06.0', expected: '18.06.0.ce' },
-        {  docker_version: '18.06.1', expected: '18.06.1.ce' },
-        {  docker_version: '18.09.0', expected: '18.09.0' },
-        {  docker_version: '19.03.5', expected: '19.03.5' },
-    ].each do |suite|
-      it 'generates the correct version string fedora' do
-        custom_resource = chef_run.docker_installation_package('default')
-        actual = custom_resource.version_string(suite[:docker_version])
-        expect(actual).to eq(suite[:expected])
-      end
-    end
-  end
 end

--- a/test/cookbooks/docker_test/recipes/installation_package.rb
+++ b/test/cookbooks/docker_test/recipes/installation_package.rb
@@ -1,4 +1,4 @@
 docker_installation_package 'default' do
-  version '19.03'
+  version '19.03.8'
   action :create
 end


### PR DESCRIPTION
Chef Infra Client 15 reworked how versions are handled and made it so we can do versions like 19.03.3*. This means we can take the version in from the user and just do the right thing without constantly updating fragile helpers that build the full version string. We sadly still have that logic for Debian/Ubuntu, but baby steps.

Signed-off-by: Tim Smith <tsmith@chef.io>