### PR TITLE
Container being redeployd fixes

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -39,7 +39,7 @@ module DockerCookbook
     property :ip_address, String
     property :mac_address, String
     property :memory, [String, Integer], coerce: proc { |v| coerce_to_bytes(v) }, default: 0
-    property :memory_swap, [String, Integer], coerce: proc { |v| coerce_to_bytes(v) }, default: 0
+    property :memory_swap, [String, Integer], coerce: proc { |v| coerce_to_bytes(v) }
     property :memory_swappiness, Integer, default: 0
     property :memory_reservation, Integer, coerce: proc { |v| coerce_to_bytes(v) }, default: 0
     property :network_disabled, [true, false], default: false
@@ -73,7 +73,7 @@ module DockerCookbook
     property :volumes, PartialHashType, default: {}, coerce: proc { |v| coerce_volumes(v) }
     property :volumes_from, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }
     property :volume_driver, String
-    property :working_dir, String, default: ''
+    property :working_dir, String
 
     # Used to store the bind property since binds is an alias to volumes
     property :volumes_binds, Array

--- a/spec/docker_test/container_spec.rb
+++ b/spec/docker_test/container_spec.rb
@@ -35,7 +35,7 @@ describe 'docker_test::container' do
         domain_name: '',
         log_driver: 'json-file',
         memory: 0,
-        memory_swap: 0,
+        memory_swap: nil,
         network_disabled: false,
         outfile: nil,
         restart_maximum_retry_count: 0,


### PR DESCRIPTION
Container being redeployed after every chef-run.

### Description
- Removed default value for properties working_dir and memory_swap.

### Issues Resolved
#1092

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>