### PR TITLE
Fix for docker_exec does not check the return code of the command it runs

### DIFF
--- a/libraries/docker_exec.rb
+++ b/libraries/docker_exec.rb
@@ -7,13 +7,20 @@ module DockerCookbook
     property :container, String
     property :timeout, Numeric, default: 60, desired_state: false
     property :container_obj, Docker::Container, desired_state: false
+    property :returns, [ Integer, Array ], coerce: proc { |v| Array(v) }, default: [0],
+      description: 'The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.'
 
     alias_method :cmd, :command
 
     action :run do
       converge_by "executing #{new_resource.command} on #{new_resource.container}" do
         with_retries { new_resource.container_obj Docker::Container.get(new_resource.container, {}, connection) }
-        new_resource.container_obj.exec(new_resource.command, wait: new_resource.timeout)
+        stdout, stderr, exit_code = new_resource.container_obj.exec(new_resource.command, wait: new_resource.timeout)
+        Chef::Log.trace(stdout)
+        Chef::Log.trace(stderr)
+        unless new_resource.returns.include?(exit_code)
+          raise "Expected process to exit with 0, but received #{exit_code}"
+        end
       end
     end
   end

--- a/spec/docker_test/exec_spec.rb
+++ b/spec/docker_test/exec_spec.rb
@@ -14,6 +14,19 @@ describe 'docker_test::exec' do
     )
   end
 
+  context 'testing default properties' do
+    it 'docker_exec[default]' do
+      expect(chef_run).to run_docker_exec('default').with(
+        host: nil,
+        command: nil,
+        container: nil,
+        timeout: 60,
+        container_obj: nil,
+        returns: [0]
+      )
+    end
+  end
+
   context 'testing run action' do
     it 'run docker_exec[touch_it]' do
       expect(chef_run).to run_docker_exec('touch_it').with(

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -9,7 +9,7 @@ describe 'docker_test::installation_package' do
 
   context 'testing default action, default properties' do
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '19.03.5')
+      expect(chef_run).to create_docker_installation_package('default').with(version: '19.03.8')
     end
   end
 

--- a/test/cookbooks/docker_test/recipes/exec.rb
+++ b/test/cookbooks/docker_test/recipes/exec.rb
@@ -23,3 +23,5 @@ docker_exec 'poke_it' do
 end
 
 file '/marker_busybox_exec_twofile'
+
+docker_exec 'default'


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- `docker_exec` resource was not failing if the command fails, so we have fixed it.
- Added `returns` property

### Issues Resolved
Fixes: #1081 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>