### PR TITLE
Revert #1113 for breaking backwards-compat for chef <16

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerContainer < DockerBase
-    provides :docker_container
+    resource_name :docker_container
 
     property :container_name, String, name_property: true
     property :repo, String, default: lazy { container_name }

--- a/libraries/docker_exec.rb
+++ b/libraries/docker_exec.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerExec < DockerBase
-    provides :docker_exec
+    resource_name :docker_exec
 
     property :host, [String, nil], default: lazy { ENV['DOCKER_HOST'] }, desired_state: false
     property :command, Array

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerImage < DockerBase
-    provides :docker_image
+    resource_name :docker_image
 
     # Modify the default of read_timeout from 60 to 120
     property :read_timeout, default: 120, desired_state: false

--- a/libraries/docker_image_prune.rb
+++ b/libraries/docker_image_prune.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerImagePrune < DockerBase
-    provides :docker_image_prune
+    resource_name :docker_image_prune
     # Requires docker API v1.25
     # Modify the default of read_timeout from 60 to 120
     property :read_timeout, default: 120, desired_state: false

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerInstallationPackage < DockerBase
-    provides :docker_installation_package
+    resource_name :docker_installation_package
 
     property :setup_docker_repo, [true, false], default: true, desired_state: false
     property :repo_channel, String, default: 'stable'

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerInstallationTarball < DockerBase
-    provides :docker_installation_tarball
+    resource_name :docker_installation_tarball
 
     property :checksum, String, default: lazy { default_checksum }, desired_state: false
     property :source, String, default: lazy { default_source }, desired_state: false

--- a/libraries/docker_network.rb
+++ b/libraries/docker_network.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerNetwork < DockerBase
-    provides :docker_network
+    resource_name :docker_network
 
     property :auxiliary_addresses, [String, Array, nil], coerce: proc { |v| coerce_auxiliary_addresses(v) }
     property :container, String, desired_state: false

--- a/libraries/docker_plugin.rb
+++ b/libraries/docker_plugin.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerPlugin < DockerBase
-    provides :docker_plugin
+    resource_name :docker_plugin
 
     property :local_alias, String, name_property: true
     property :remote_tag, String, default: 'latest'

--- a/libraries/docker_registry.rb
+++ b/libraries/docker_registry.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerRegistry < DockerBase
-    provides :docker_registry
+    resource_name :docker_registry
 
     property :email, String
 

--- a/libraries/docker_service_manager_execute.rb
+++ b/libraries/docker_service_manager_execute.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerServiceManagerExecute < DockerServiceBase
-    provides :docker_service_manager_execute
+    resource_name :docker_service_manager_execute
 
     # Start the service
     action :start do

--- a/libraries/docker_tag.rb
+++ b/libraries/docker_tag.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerTag < DockerBase
-    provides :docker_tag
+    resource_name :docker_tag
 
     property :target_repo, String, name_property: true
     property :target_tag, String

--- a/libraries/docker_volume.rb
+++ b/libraries/docker_volume.rb
@@ -1,6 +1,6 @@
 module DockerCookbook
   class DockerVolume < DockerBase
-    provides :docker_volume
+    resource_name :docker_volume
 
     property :driver, String, desired_state: false
     property :host, [String, nil], default: lazy { ENV['DOCKER_HOST'] }, desired_state: false


### PR DESCRIPTION
Reverts #1113

### Description
This broke Chef 15

```
Chef::Exceptions::InvalidResourceSpecification: [my_docker_registry].resource_name is `nil`!  Did you forget to put `provides :blah` or `resource_name :blah` in your resource class?
```

Source:
https://github.com/chef/chef/blob/2f78efa0f657c67ea1d8ec04b8fcd645f36d7c7e/lib/chef/resource_builder.rb#L47-L49

### Issues Resolved
#1115 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>