### PR TITLE
404 to documentation images fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ end
 
 The `docker_container` is responsible for managing Docker container actions. It speaks directly to the [Docker remote API](https://docs.docker.com/reference/api/docker_remote_api_v1.20/).
 
-Containers are process oriented, and move through an event cycle. Thanks to [Glider Labs](http://gliderlabs.com/) for this excellent diagram. ![alt tag](https://gliderlabs.com/images/2015/docker_events.png)
+Containers are process oriented, and move through an event cycle. Thanks to [Glider Labs](http://gliderlabs.com/) for this excellent diagram. [alt tag](https://gliderlabs.com/images/2015/docker_events.png)
 
 ### Actions
 

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -451,7 +451,7 @@ module DockerCookbook
     #########
 
     # Super handy visual reference!
-    # http://gliderlabs.com/images/docker_events.png
+    # https://gliderlabs.com/images/2015/docker_events.png
 
     # Loads container specific labels excluding those of engine or image.
     # This insures idempotency.


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

## Fixed 404 to README doc images references issue

### Description
- Updated reference URL

### Issues Resolved
- #984 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>