### PR TITLE
added ability to upgrade package installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ end
 
 ### Properties
 
-- `version` - Used to calculate package_version string. On Ubuntu / Debian this needs to be the complete version (19.03.8) while on Fedora / RHEL this can be any valid version string (19, 19.03, 19.03.8). We add an asterisk on automatically on RHEL/Fedora so leave that out.
+- `version` - Used to calculate package_version string. This needs to be the complete version (19.03.8).
 - `package_version` - Manually specify the package version string
 - `package_name` - Name of package to install. Defaults to 'docker-ce'
 - `package_options` - Manually specify additional options, like apt-get directives for example


### PR DESCRIPTION
Signed-off-by: Corey Hemminger <hemminger@hotmail.com>
### Description
Adds the ability to install latest package version by not specifying package_version property or version property. Maintains backwards compatibility by still defaulting to old functionality if version is specified it'll calculate debain family package version properly and ensure system has that version installed or revert system back if newer package is found. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x ] New functionality includes testing.
- [x ] New functionality has been documented in the README if applicable
- [x ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>