### PR TITLE
chore(style): Cookstyle Fixes

### DIFF
--- a/libraries/helpers_network.rb
+++ b/libraries/helpers_network.rb
@@ -13,7 +13,7 @@ module DockerCookbook
         # It might also not match the new_resource value
         if container.info['NetworkSettings'] &&
            container.info['NetworkSettings']['Networks'] &&
-           container.info['NetworkSettings']['Networks'].values[0] &&
+           container.info['NetworkSettings']['Networks'].values.first &&
            container.info['NetworkSettings']['Networks'].values[0]['IPAMConfig'] &&
            container.info['NetworkSettings']['Networks'].values[0]['IPAMConfig']['IPv4Address']
           # Return the ip address listed

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -115,10 +115,10 @@ module DockerCookbook
         Array(v).each_with_object([]) do |label, a|
           if label =~ /:/
             parts = label.split(':')
-            a << "#{parts[0]}=\"#{parts[1]}\""
+            a << "#{parts.first}=\"#{parts[1]}\""
           elsif label =~ /=/
             parts = label.split('=')
-            a << "#{parts[0]}=#{parts[1]}"
+            a << "#{parts.first}=#{parts[1]}"
           else
             Chef::Log.info("WARNING: docker_service label #{label} not valid")
           end

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -68,7 +68,7 @@ property :stdin_once, [true, false], default: false, desired_state: false
 property :sysctls, Hash, default: {}
 property :timeout, Integer, desired_state: false
 property :tmpfs, [Hash, Array], default: {}, coerce: proc { |v| coerce_tmpfs(v) },
-  description: 'A hash or array of tmpfs mounts to add to the container. Hash format: { "/path" => "size=100M,uid=1000" }. Array format: ["/path", "/path2"]. See https://docs.docker.com/storage/tmpfs/'
+                                description: 'A hash or array of tmpfs mounts to add to the container. Hash format: { "/path" => "size=100M,uid=1000" }. Array format: ["/path", "/path2"]. See https://docs.docker.com/storage/tmpfs/'
 property :tty, [true, false], default: false
 property :ulimits, [Array, nil], coerce: proc { |v| coerce_ulimits(v) }
 property :user, String
@@ -82,7 +82,7 @@ property :gpus, [String, nil], description: 'GPU devices to add to the container
 property :gpu_driver, String, default: 'nvidia', description: 'GPU driver to use for container (e.g., nvidia)'
 
 # Used to store the bind property since binds is an alias to volumes
-property :volumes_binds, Array, coerce: proc { |v| v.sort }
+property :volumes_binds, Array, coerce: proc(&:sort)
 
 # Used to store the state of the Docker container
 property :container, Docker::Container, desired_state: false
@@ -201,7 +201,7 @@ def coerce_volumes(v)
     PartialHash[v]
   else
     b = []
-    v = Array(v).to_a # in case v.is_A?(Chef::Node::ImmutableArray)
+    v = Array(v) # in case v.is_A?(Chef::Node::ImmutableArray)
     v.delete_if do |x|
       parts = x.split(':')
       b << x if parts.length > 1
@@ -255,27 +255,27 @@ def parse_port(v)
   parts = v.split(':')
   case parts.length
   when 3
-    host_ip = parts[0]
+    host_ip = parts.first
     host_port = parts[1].split('-')
     container_port = parts[2].split('-')
   when 2
     host_ip = '0.0.0.0'
-    host_port = parts[0].split('-')
+    host_port = parts.first.split('-')
     container_port = parts[1].split('-')
   when 1
     host_ip = ''
     host_port = ['']
-    container_port = parts[0].split('-')
+    container_port = parts.first.split('-')
   end
   host_port.map!(&:to_i) unless host_port == ['']
   container_port.map!(&:to_i)
   if host_port.count > 1
-    Chef::Log.fatal("FATAL: Invalid port range! #{host_port}") if host_port[0] > host_port[1]
-    host_port = (host_port[0]..host_port[1]).to_a
+    Chef::Log.fatal("FATAL: Invalid port range! #{host_port}") if host_port.first > host_port[1]
+    host_port = (host_port.first..host_port[1]).to_a
   end
   if container_port.count > 1
-    Chef::Log.fatal("FATAL: Invalid port range! #{container_port}") if container_port[0] > container_port[1]
-    container_port = (container_port[0]..container_port[1]).to_a
+    Chef::Log.fatal("FATAL: Invalid port range! #{container_port}") if container_port.first > container_port[1]
+    container_port = (container_port.first..container_port[1]).to_a
   end
   Chef::Log.fatal('FATAL: Port range size does not match!') if host_port.count > 1 && host_port.count != container_port.count
   # qualify the port-binding protocol even when it is implicitly tcp #427.
@@ -403,7 +403,7 @@ load_current_value do |new_resource|
 
   # reload_signal is not persisted elsewhere, and will cause container
   # to restart if different from the default value
-  public_send('reload_signal', new_resource.reload_signal)
+  reload_signal(new_resource.reload_signal)
 
   # Go through everything in the container and set corresponding properties:
   # c.info['Config']['ExposedPorts'] -> exposed_ports
@@ -456,7 +456,7 @@ def load_container_labels
       engine_labels.any? { |k, v| k == key && v == val }
   end
 
-  public_send(:labels, labels)
+  labels(labels)
 end
 
 action :run do
@@ -474,71 +474,71 @@ action :create do
 
     with_retries do
       config = {
-        'name'            => new_resource.container_name,
-        'Image'           => new_resource.tag.to_s.start_with?('sha256:') ? "#{new_resource.repo}@#{new_resource.tag}" : "#{new_resource.repo}:#{new_resource.tag}",
-        'Labels'          => new_resource.labels,
-        'Cmd'             => to_shellwords(new_resource.command),
-        'AttachStderr'    => new_resource.attach_stderr,
-        'AttachStdin'     => new_resource.attach_stdin,
-        'AttachStdout'    => new_resource.attach_stdout,
-        'Domainname'      => new_resource.domain_name,
-        'Entrypoint'      => to_shellwords(new_resource.entrypoint),
-        'Env'             => new_resource.env + read_env_file,
-        'ExposedPorts'    => new_resource.exposed_ports,
-        'Healthcheck'     => new_resource.health_check,
-        'Hostname'        => parsed_hostname,
-        'MacAddress'      => new_resource.mac_address,
+        'name' => new_resource.container_name,
+        'Image' => new_resource.tag.to_s.start_with?('sha256:') ? "#{new_resource.repo}@#{new_resource.tag}" : "#{new_resource.repo}:#{new_resource.tag}",
+        'Labels' => new_resource.labels,
+        'Cmd' => to_shellwords(new_resource.command),
+        'AttachStderr' => new_resource.attach_stderr,
+        'AttachStdin' => new_resource.attach_stdin,
+        'AttachStdout' => new_resource.attach_stdout,
+        'Domainname' => new_resource.domain_name,
+        'Entrypoint' => to_shellwords(new_resource.entrypoint),
+        'Env' => new_resource.env + read_env_file,
+        'ExposedPorts' => new_resource.exposed_ports,
+        'Healthcheck' => new_resource.health_check,
+        'Hostname' => parsed_hostname,
+        'MacAddress' => new_resource.mac_address,
         'NetworkDisabled' => new_resource.network_disabled,
-        'OpenStdin'       => new_resource.open_stdin,
-        'StdinOnce'       => new_resource.stdin_once,
-        'Tty'             => new_resource.tty,
-        'User'            => new_resource.user,
-        'Volumes'         => new_resource.volumes,
-        'WorkingDir'      => new_resource.working_dir,
-        'HostConfig'      => {
-          'Binds'           => new_resource.volumes_binds,
-          'CapAdd'          => new_resource.cap_add,
-          'CapDrop'         => new_resource.cap_drop,
-          'CgroupParent'    => new_resource.cgroup_parent,
-          'CgroupnsMode'    => new_resource.cgroup_ns,
-          'CpuShares'       => new_resource.cpu_shares,
-          'CpusetCpus'      => new_resource.cpuset_cpus,
-          'Devices'         => new_resource.devices,
-          'Dns'             => new_resource.dns,
-          'DnsSearch'       => new_resource.dns_search,
-          'ExtraHosts'      => new_resource.extra_hosts,
-          'IpcMode'         => new_resource.ipc_mode,
-          'Init'            => new_resource.init,
-          'KernelMemory'    => new_resource.kernel_memory,
-          'Links'           => new_resource.links,
-          'LogConfig'       => log_config,
-          'Memory'          => new_resource.memory,
-          'MemorySwap'      => new_resource.memory_swap,
+        'OpenStdin' => new_resource.open_stdin,
+        'StdinOnce' => new_resource.stdin_once,
+        'Tty' => new_resource.tty,
+        'User' => new_resource.user,
+        'Volumes' => new_resource.volumes,
+        'WorkingDir' => new_resource.working_dir,
+        'HostConfig' => {
+          'Binds' => new_resource.volumes_binds,
+          'CapAdd' => new_resource.cap_add,
+          'CapDrop' => new_resource.cap_drop,
+          'CgroupParent' => new_resource.cgroup_parent,
+          'CgroupnsMode' => new_resource.cgroup_ns,
+          'CpuShares' => new_resource.cpu_shares,
+          'CpusetCpus' => new_resource.cpuset_cpus,
+          'Devices' => new_resource.devices,
+          'Dns' => new_resource.dns,
+          'DnsSearch' => new_resource.dns_search,
+          'ExtraHosts' => new_resource.extra_hosts,
+          'IpcMode' => new_resource.ipc_mode,
+          'Init' => new_resource.init,
+          'KernelMemory' => new_resource.kernel_memory,
+          'Links' => new_resource.links,
+          'LogConfig' => log_config,
+          'Memory' => new_resource.memory,
+          'MemorySwap' => new_resource.memory_swap,
           'MemorySwappiness' => new_resource.memory_swappiness,
           'MemoryReservation' => new_resource.memory_reservation,
-          'NanoCpus'        => new_resource.cpus,
-          'NetworkMode'     => normalize_container_network_mode(new_resource.network_mode),
-          'OomKillDisable'  => new_resource.oom_kill_disable,
-          'OomScoreAdj'     => new_resource.oom_score_adj,
-          'Privileged'      => new_resource.privileged,
-          'PidMode'         => new_resource.pid_mode,
-          'PortBindings'    => new_resource.port_bindings,
+          'NanoCpus' => new_resource.cpus,
+          'NetworkMode' => normalize_container_network_mode(new_resource.network_mode),
+          'OomKillDisable' => new_resource.oom_kill_disable,
+          'OomScoreAdj' => new_resource.oom_score_adj,
+          'Privileged' => new_resource.privileged,
+          'PidMode' => new_resource.pid_mode,
+          'PortBindings' => new_resource.port_bindings,
           'PublishAllPorts' => new_resource.publish_all_ports,
-          'RestartPolicy'   => {
-            'Name'              => new_resource.restart_policy,
+          'RestartPolicy' => {
+            'Name' => new_resource.restart_policy,
             'MaximumRetryCount' => new_resource.restart_maximum_retry_count,
           },
-          'ReadonlyRootfs'  => new_resource.ro_rootfs,
-          'Runtime'         => new_resource.runtime,
-          'SecurityOpt'     => new_resource.security_opt,
-          'ShmSize'         => new_resource.shm_size,
-          'Sysctls'         => new_resource.sysctls,
-          'Tmpfs'           => new_resource.tmpfs,
-          'Ulimits'         => ulimits_to_hash,
-          'UsernsMode'      => new_resource.userns_mode,
-          'UTSMode'         => new_resource.uts_mode,
-          'VolumesFrom'     => new_resource.volumes_from,
-          'VolumeDriver'    => new_resource.volume_driver,
+          'ReadonlyRootfs' => new_resource.ro_rootfs,
+          'Runtime' => new_resource.runtime,
+          'SecurityOpt' => new_resource.security_opt,
+          'ShmSize' => new_resource.shm_size,
+          'Sysctls' => new_resource.sysctls,
+          'Tmpfs' => new_resource.tmpfs,
+          'Ulimits' => ulimits_to_hash,
+          'UsernsMode' => new_resource.userns_mode,
+          'UTSMode' => new_resource.uts_mode,
+          'VolumesFrom' => new_resource.volumes_from,
+          'VolumeDriver' => new_resource.volume_driver,
         },
       }
       net_config = {
@@ -694,7 +694,7 @@ action_class do
       raise Chef::Exceptions::ValidationFailed, 'restart_policy must be either no, always, unless-stopped, or on-failure.'
     end
 
-    if new_resource.autoremove == true && (new_resource.property_is_set?(:restart_policy) && new_resource.restart_policy != 'no')
+    if new_resource.autoremove == true && new_resource.property_is_set?(:restart_policy) && new_resource.restart_policy != 'no'
       raise Chef::Exceptions::ValidationFailed, 'Conflicting options restart_policy and autoremove.'
     end
 
@@ -749,8 +749,8 @@ action_class do
   def ulimits_to_hash
     return if new_resource.ulimits.nil?
     new_resource.ulimits.map do |u|
-      name = u.split('=')[0]
-      soft = u.split('=')[1].split(':')[0]
+      name = u.split('=').first
+      soft = u.split('=')[1].split(':').first
       hard = u.split('=')[1].split(':')[1]
       { 'Name' => name, 'Soft' => soft.to_i, 'Hard' => hard.to_i }
     end

--- a/resources/exec.rb
+++ b/resources/exec.rb
@@ -7,7 +7,7 @@ property :container, String
 property :timeout, Numeric, default: 60, desired_state: false
 property :container_obj, Docker::Container, desired_state: false
 property :returns, [ Integer, Array ], coerce: proc { |v| Array(v) }, default: [0],
-  description: 'The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.'
+                                       description: 'The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match.'
 
 alias_method :cmd, :command
 

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -119,12 +119,12 @@ def version_string(v)
 
   if v.to_f < 18.06 && !bionic?
     return "#{v}~ce-0~debian" if debian?
-    return "#{v}~ce-0~ubuntu" if ubuntu?
+    "#{v}~ce-0~ubuntu" if ubuntu?
   elsif v.to_f >= 23.0 && ubuntu?
     "5:#{v}-1~ubuntu.#{node['platform_version']}~#{codename}"
   elsif v.to_f >= 18.09 && debuntu?
     return "5:#{v}~#{test_version}-0~debian-#{codename}" if debian?
-    return "5:#{v}~#{test_version}-0~ubuntu-#{codename}" if ubuntu?
+    "5:#{v}~#{test_version}-0~ubuntu-#{codename}" if ubuntu?
   else
     return "#{v}~ce~#{test_version}-0~debian" if debian?
     return "#{v}~ce~#{test_version}-0~ubuntu" if ubuntu?
@@ -191,7 +191,7 @@ action :create do
         # TODO: This eventually should go away once Debian 12 and Ubuntu 24.04 go EOL
         if (debian? && node['platform_version'].to_i < 13) || (ubuntu? && node['platform_version'].to_f <= 24.04)
           signed_by false
-        end if Chef::VERSION >= Gem::Version.new('18.7.10')
+        end if Gem::Version.new('18.7.10') <= Chef::VERSION
         action :add
       end
 

--- a/resources/network.rb
+++ b/resources/network.rb
@@ -36,25 +36,25 @@ def coerce_auxiliary_addresses(v)
       e.each { |key, val| ray << "#{key}=#{val}" }
     end
   end
-  ray.length == 1 ? ray[0] : ray
+  ray.length == 1 ? ray.first : ray
 end
 
 def coerce_gateway(v)
   case v
   when String
-    v.split('/')[0]
+    v.split('/').first
   when Array
-    ray = Array(v).map { |a| a.split('/')[0] }
-    ray.length == 1 ? ray[0] : ray
+    ray = Array(v).map { |a| a.split('/').first }
+    ray.length == 1 ? ray.first : ray
   end
 end
 
 def coerce_subnet(v)
-  Array(v).length == 1 ? Array(v)[0] : v
+  Array(v).length == 1 ? Array(v).first : v
 end
 
 def coerce_ip_range(v)
-  Array(v).length == 1 ? Array(v)[0] : v
+  Array(v).length == 1 ? Array(v).first : v
 end
 
 ####################
@@ -219,7 +219,7 @@ action_class do
 
     # Check overlapping subnets
     subnets.each do |s|
-      data.each do |k, _|
+      data.each_key do |k|
         if subnet_matches(s, k) || subnet_matches(k, s)
           raise 'multiple overlapping subnet configuration is not supported'
         end

--- a/resources/partial/_base.rb
+++ b/resources/partial/_base.rb
@@ -27,9 +27,9 @@ def with_retries(&_block)
     yield
   # Only catch errors that can be fixed with retries.
   rescue Docker::Error::ServerError, # 500
-          Docker::Error::UnexpectedResponseError, # 400
-          Docker::Error::TimeoutError,
-          Docker::Error::IOError
+         Docker::Error::UnexpectedResponseError, # 400
+         Docker::Error::TimeoutError,
+         Docker::Error::IOError
     tries -= 1
     retry if tries > 0
     raise

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -311,10 +311,10 @@ docker_container 'tmpfs_test' do
   tag '3.1'
   command 'df -h'
   tmpfs({
-    '/tmpfs1' => '',
-    '/tmpfs2' => 'size=20M,uid=1000',
-    '/tmpfs3' => 'rw,noexec,nosuid,size=50M',
-  })
+          '/tmpfs1' => '',
+          '/tmpfs2' => 'size=20M,uid=1000',
+          '/tmpfs3' => 'rw,noexec,nosuid,size=50M',
+        })
   action :run_if_missing
 end
 


### PR DESCRIPTION
# Cookstyle Automated Changes

This pull request applies automatic Cookstyle fixes to ensure code quality and consistency.

## Changes Made

* **libraries/helpers_network.rb**: Style/ArrayFirstLast
* **libraries/helpers_service.rb**: Style/ArrayFirstLast
* **resources/container.rb**: Layout/HashAlignment, Style/SymbolProc, Lint/RedundantTypeConversion, Style/ArrayFirstLast, Style/SendWithLiteralMethodName, Style/RedundantParentheses
* **resources/exec.rb**: Layout/HashAlignment
* **resources/installation_package.rb**: Style/RedundantReturn, Style/YodaCondition
* **resources/network.rb**: Style/ArrayFirstLast, Style/HashEachMethods
* **resources/partial/_base.rb**: Layout/ArrayAlignment
* **test/cookbooks/docker_test/recipes/container.rb**: Layout/FirstHashElementIndentation
### Summary

* Total offenses detected: 93
* Files with issues: 8

*This issue was automatically generated by the [GitHub Cookstyle Runner](https://github.com/damacus/github-cookstyle-runner).*
